### PR TITLE
model→helperへ定義場所の修正(Feature/#83 fix reservation calendar definition)

### DIFF
--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -167,8 +167,12 @@ mypage-main{/*画面中央*/
     }
 
     .mypage-info-icon-image{
-      margin: 20px 0px 0px 10px;
+      margin: 13px 0px 0px 15px;
+      width: 60px;
+      height: 60px;
       border-radius: 100%;
+      display: inline-block;
+      object-fit: cover;
     }
   }
 
@@ -487,9 +491,17 @@ main {/*画面中央*/
     #my-page-info-content {
       padding: 13px 18px;
 
+      .media-left {
+        margin-right: 8px;
+      }
+
       .mypage-info-icon-image{
-        margin: 15px 0px 0px 11px;
+        margin: 5px 0px 0px 11px;
+        width: 60px;
+        height: 60px;
         border-radius: 100%;
+        display: inline-block;
+        object-fit: cover;
       }
     }
   }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -10,12 +10,4 @@ module ApplicationHelper
   def devise_mapping
 		@devise_mapping ||= Devise.mappings[:user]
   end
-
-  def grouped_facility(information)
-    information.group_by(&:facility_id)
-  end
-
-  def mypage_informations_name(id)
-    Facility.find(id).facility_name
-  end
 end

--- a/app/helpers/informations_helper.rb
+++ b/app/helpers/informations_helper.rb
@@ -6,4 +6,21 @@ module InformationsHelper
       image_tag "https://img-photo.s3-ap-northeast-1.amazonaws.com/uploads/content_image/info.jpg", id: :img_prev, :size => '500x500'
     end
   end
+
+  # facility_idごとにグループ分けする
+  def grouped_facility(information)
+    information.group_by(&:facility_id)
+  end
+
+  # 施設のiconを表示
+  def mypage_informations_icon(id)
+    facility = Facility.find(id)
+    return image_tag facility.icon.url, class: "mypage-info-icon-image" if facility.icon?
+    image_tag 'https://img-photo.s3-ap-northeast-1.amazonaws.com/uploads/content_image/facility_default.png', class: "mypage-info-icon-image"
+  end
+
+  # 自分が登録している施設のお知らせで、statusがothersであるものを全て取得する
+  def mypage_informations(id)
+    Information.where(facility_id: id).where(status: "others")
+  end
 end

--- a/app/helpers/reservations_helper.rb
+++ b/app/helpers/reservations_helper.rb
@@ -1,2 +1,5 @@
 module ReservationsHelper
+  def calendar_reservation
+    Reservation.where.not(calendar_day: nil)
+  end
 end

--- a/app/models/information.rb
+++ b/app/models/information.rb
@@ -8,7 +8,4 @@ class Information < ApplicationRecord
 
   # モデル | ImageUploaderクラスとimageカラムを紐づける
   mount_uploader :image, ImageUploader
-
-  # 自分が登録している施設のお知らせであり、statusがothersであるものを取得する
-  scope :mypage_informations, -> (id){ where(facility_id: id).where(status: "others") }
 end

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -1,7 +1,3 @@
 class Reservation < ApplicationRecord
   belongs_to :user
-
-  def self.calendar_reservation
-    Reservation.where.not(calendar_day: nil)
-  end
 end

--- a/app/views/facilities/facility_home.html.erb
+++ b/app/views/facilities/facility_home.html.erb
@@ -78,7 +78,7 @@
         <div id="Web" class="content-tab" >
           <div class="has-text-centered" id="calendar-reservations">
             <div class="is-centered">
-              <%= month_calendar(attribute: :calendar_day, events: Reservation.calendar_reservation) do |date, reservations| %>
+              <%= month_calendar(attribute: :calendar_day, events: calendar_reservation) do |date, reservations| %>
                 <%= l(date, format: :short) %>
               <% end %>
             </div><br>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -69,7 +69,7 @@
           <div class="card" id="mypage-reservations-calendar">
             <div class="has-text-centered">
               <div class="is-centered">
-                <%= month_calendar(attribute: :calendar_day, events: Reservation.calendar_reservation) do |date, reservations| %>
+                <%= month_calendar(attribute: :calendar_day, events: calendar_reservation) do |date, reservations| %>
                   <%= l(date, format: :short) %>
                 <% end %>
               </div><br>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -26,17 +26,13 @@
         <div class="Web-section">
           <div class="columns">
             <% grouped_facility(@informations).each do |facility_id, other| %>
-              <% @infors = Information.mypage_informations(facility_id) %>
               <div class="card-content" id="my-page-info-content">
                 <div class="card" style="display: flex; border-radius: 11px;">
                   <div class="media-left">
-                    <figure class="image is-48x48">
-                      <img src="https://bulma.io/images/placeholders/96x96.png" alt="Placeholder image"  class="mypage-info-icon-image">
-                    </figure>
-                    <small><%#= mypage_informations_name(facility_id) %></small> <!-- 施設アイコン画像が設定できるようになったら、名前→アイコン画像に修正する -->
+                    <small><%= mypage_informations_icon(facility_id) %></small>
                   </div>
                   <div class="media-content" id="web-media-section">
-                    <% @infors.last(2).each do |information| %>
+                    <% mypage_informations(facility_id).last(2).each do |information| %>
                     <div class="mypage-information">
                       <div>
                         <div class="box" id="mypage-user-box">


### PR DESCRIPTION
## Issueへのリンク
* https://github.com/hayaminahiro/family_online_visit/issues/93#issue-728996793

## 実装内容
* viewに表示するためのデータをmodelで定義し呼び出していたので、reservations_helperに修正。
* 同様にscope（informationモデルに定義）でviewに表示するための定義を使用していたのでinformations_helperに修正。
* マイページのお知らせ表示で施設アイコンを表示できるように修正しました。


## やらないこと
* このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）

## できるようになること（ユーザ目線）
* 何ができるようになるのか？（あれば。無いなら「無し」でOK）

## できなくなること（ユーザ目線）
* 何ができなくなるのか？（あれば。無いなら「無し」でOK）

## 動作確認
* どのような動作確認を行ったのか？　結果はどうか？

## その他
* レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）

## 画像
