### PR TITLE
デコレータの追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,7 @@ gem 'fog-aws'
 gem 'mini_magick'
 gem "dropzonejs-rails"
 gem 'activerecord-import'
+gem 'active_decorator'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,6 +24,8 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
+    active_decorator (1.3.3)
+      activesupport
     activejob (5.2.4.3)
       activesupport (= 5.2.4.3)
       globalid (>= 0.3.6)
@@ -316,6 +318,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_decorator
   activerecord-import
   better_errors
   binding_of_caller

--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -50,6 +50,7 @@
 mypage-aside {/*画面左*/
   position: fixed;
   width: 15.5%;
+  height: 100%;
   font-size:15px;
   display: flex;
   flex-direction: column;
@@ -135,7 +136,7 @@ mypage-aside {/*画面左*/
 }
 
 mypage-main{/*画面中央*/
-  margin-left: 15.5%;
+  padding-left: 15.5%;
   width: 100%;
   background-color: rgb(244,243,238);
   display: flex;
@@ -161,16 +162,29 @@ mypage-main{/*画面中央*/
   #my-page-info-content{
     padding: 21px 18px;
 
+    .media-left {
+      margin-right: 8px;
+      width: 71px;
+    }
+
     #web-media-section{
       display: flex;
       border-left: solid 1px rgb(238,236,228);
     }
 
-    .mypage-info-icon-image{
+    .mypage-facility-icon-image{
       margin: 13px 0px 0px 15px;
       width: 60px;
       height: 60px;
       border-radius: 100%;
+      display: inline-block;
+      object-fit: cover;
+    }
+
+    .mypage-info-icon-image{
+      margin: 3px 10px 0px 0px;
+      width: 45px;
+      height: 45px;
       display: inline-block;
       object-fit: cover;
     }
@@ -260,6 +274,11 @@ mypage-main{/*画面中央*/
   margin: 35px 16px 13px 10px;
   font-size: 17px;
   border-radius: 6px;
+
+  .card-content {
+    background-color: transparent;
+    padding: 1.5rem;
+  }
 }
 
 .mypage-information{
@@ -268,8 +287,8 @@ mypage-main{/*画面中央*/
 }
 
 #mypage-user-box{
-  width: 228px;
-  padding: 10px 10px 0px 10px;
+  width: 188px;
+  padding: 8px 10px 7px 10px;
   margin: 8px 10px 8px 15px;
   border: solid 1px #9daba6;
 
@@ -474,7 +493,7 @@ main {/*画面中央*/
 
 
   mypage-main {
-    margin-left: 0;
+    padding-left: 0px;
     width: 100%;
     display: flex;
 
@@ -492,14 +511,24 @@ main {/*画面中央*/
       padding: 13px 18px;
 
       .media-left {
-        margin-right: 8px;
+        margin-right: 0px;
+        margin-left: 5px;
+      }
+
+      .mypage-facility-icon-image{
+        margin: 10px 0px 0px 9px;
+        width: 50px;
+        height: 50px;
+        border-radius: 100%;
+        display: inline-block;
+        object-fit: cover;
       }
 
       .mypage-info-icon-image{
-        margin: 5px 0px 0px 11px;
-        width: 60px;
-        height: 60px;
-        border-radius: 100%;
+        margin-right: 8px;
+        margin-top: 0px;
+        width: 40px;
+        height: 40px;
         display: inline-block;
         object-fit: cover;
       }

--- a/app/controllers/facilities_controller.rb
+++ b/app/controllers/facilities_controller.rb
@@ -16,6 +16,7 @@ class FacilitiesController < ApplicationController
   end
 
   def facility_home  #施設ルートのhome画面
+    @calendar = Reservation.where.not(calendar_day: nil)
     @facilities = Facility.all.where.not(admin: true)
     @registration_application = @facilities.where(id: current_facility.users)
     @users = @facility.users.paginate(page: params[:page], per_page: 30).order(:id)

--- a/app/controllers/facilities_controller.rb
+++ b/app/controllers/facilities_controller.rb
@@ -16,7 +16,6 @@ class FacilitiesController < ApplicationController
   end
 
   def facility_home  #施設ルートのhome画面
-    @calendar = Reservation.where.not(calendar_day: nil)
     @facilities = Facility.all.where.not(admin: true)
     @registration_application = @facilities.where(id: current_facility.users)
     @users = @facility.users.paginate(page: params[:page], per_page: 30).order(:id)

--- a/app/controllers/facility_users_controller.rb
+++ b/app/controllers/facility_users_controller.rb
@@ -1,7 +1,7 @@
 class FacilityUsersController < ApplicationController
   def new
     @facility_users = Facility.all.where.not(admin: true)
-
+    @registered_facilities = current_user.facilities
     return @facility_users = @facility_users.where('facility_name LIKE ?', "%#{params[:search]}%").where.not(id: current_user.facilities).paginate(page: params[:page], per_page: 12).order(:id) if params[:search].present?
     @facility_users = @facility_users.where('facility_name LIKE ?', "")
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -18,6 +18,7 @@ class UsersController < ApplicationController
 
   def show
     @informations = Information.where(facility_id: current_user.facilities).where(status: "others")
+    @calendar = Reservation.where.not(calendar_day: nil)
   end
 
   def edit;end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -18,7 +18,6 @@ class UsersController < ApplicationController
 
   def show
     @informations = Information.where(facility_id: current_user.facilities).where(status: "others")
-    @calendar = Reservation.where.not(calendar_day: nil)
   end
 
   def edit;end

--- a/app/decorators/facility_decorator.rb
+++ b/app/decorators/facility_decorator.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 module FacilityDecorator
-  def facility_season_image(facility)
+  def facility_season_image
+    facility = Facility.find(id)
     if facility.image?
       image_tag facility.image.url, id: :img_prev, :size => '500x500'
     else
@@ -18,7 +19,8 @@ module FacilityDecorator
     end
   end
 
-  def facility_icon_image(facility)
+  def facility_icon_image
+    facility = Facility.find(id)
     if facility.icon?
       image_tag facility.icon.url, id: :icon_prev, class: "icon_circle"
     else

--- a/app/decorators/facility_decorator.rb
+++ b/app/decorators/facility_decorator.rb
@@ -2,9 +2,8 @@
 
 module FacilityDecorator
   def facility_season_image
-    facility = Facility.find(id)
-    if facility.image?
-      image_tag facility.image.url, id: :img_prev, :size => '500x500'
+    if image?
+      image_tag image.url, id: :img_prev, :size => '500x500'
     else
       month = Date.today.month
       if month.in?([ 12, 1, 2 ])
@@ -20,9 +19,8 @@ module FacilityDecorator
   end
 
   def facility_icon_image
-    facility = Facility.find(id)
-    if facility.icon?
-      image_tag facility.icon.url, id: :icon_prev, class: "icon_circle"
+    if icon?
+      image_tag icon.url, id: :icon_prev, class: "icon_circle"
     else
       image_tag 'https://img-photo.s3-ap-northeast-1.amazonaws.com/uploads/content_image/facility_default.png', id: :icon_prev, class: "icon_circle"
     end

--- a/app/decorators/facility_decorator.rb
+++ b/app/decorators/facility_decorator.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module FacilityDecorator
+  def facility_season_image(facility)
+    if facility.image?
+      image_tag facility.image.url, id: :img_prev, :size => '500x500'
+    else
+      month = Date.today.month
+      if month.in?([ 12, 1, 2 ])
+        image_tag 'https://img-photo.s3-ap-northeast-1.amazonaws.com/uploads/content_image/winter.jpg', id: :img_prev, :size => '500x500'
+      elsif month.in?([ 3, 4, 5 ])
+        image_tag 'https://img-photo.s3-ap-northeast-1.amazonaws.com/uploads/content_image/spring.jpg', id: :img_prev, :size => '500x500'
+      elsif month.in?([ 6, 7, 8 ])
+        image_tag 'https://img-photo.s3-ap-northeast-1.amazonaws.com/uploads/content_image/summer.jpg', id: :img_prev, :size => '500x500'
+      elsif month.in?([ 9, 10, 11 ])
+        image_tag 'https://img-photo.s3-ap-northeast-1.amazonaws.com/uploads/content_image/+autumn.jpg', id: :img_prev, :size => '500x500'
+      end
+    end
+  end
+
+  def facility_icon_image(facility)
+    if facility.icon?
+      image_tag facility.icon.url, id: :icon_prev, class: "icon_circle"
+    else
+      image_tag 'https://img-photo.s3-ap-northeast-1.amazonaws.com/uploads/content_image/facility_default.png', id: :icon_prev, class: "icon_circle"
+    end
+  end
+end

--- a/app/decorators/facility_decorator.rb
+++ b/app/decorators/facility_decorator.rb
@@ -25,4 +25,8 @@ module FacilityDecorator
       image_tag 'https://img-photo.s3-ap-northeast-1.amazonaws.com/uploads/content_image/facility_default.png', id: :icon_prev, class: "icon_circle"
     end
   end
+
+  def reservation_calendar
+    Reservation.where.not(calendar_day: nil)
+  end
 end

--- a/app/decorators/facility_user_decorator.rb
+++ b/app/decorators/facility_user_decorator.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+module FacilityUserDecorator
+end

--- a/app/decorators/information_decorator.rb
+++ b/app/decorators/information_decorator.rb
@@ -2,10 +2,10 @@
 
 module InformationDecorator
   def information_image
-    return image_tag "https://img-photo.s3-ap-northeast-1.amazonaws.com/uploads/content_image/info.jpg", id: :img_prev, :size => '500x500' if id == nil
-
-    info = Information.find(id)
-    return image_tag info.image.url, id: :img_prev, :size => '500x500' if info.image?
-    image_tag "https://img-photo.s3-ap-northeast-1.amazonaws.com/uploads/content_image/info.jpg", id: :img_prev, :size => '500x500'
+    if image?
+      image_tag image.url, id: :img_prev, :size => '500x500'
+    else
+      image_tag "https://img-photo.s3-ap-northeast-1.amazonaws.com/uploads/content_image/info.jpg", id: :img_prev, :size => '500x500'
+    end
   end
 end

--- a/app/decorators/information_decorator.rb
+++ b/app/decorators/information_decorator.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module InformationDecorator
+  def information_image(info)
+    if info.image?
+      image_tag info.image.url, id: :img_prev, :size => '500x500'
+    else
+      image_tag "https://img-photo.s3-ap-northeast-1.amazonaws.com/uploads/content_image/info.jpg", id: :img_prev, :size => '500x500'
+    end
+  end
+end

--- a/app/decorators/information_decorator.rb
+++ b/app/decorators/information_decorator.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 module InformationDecorator
-  def information_image(info)
-    if info.image?
-      image_tag info.image.url, id: :img_prev, :size => '500x500'
-    else
-      image_tag "https://img-photo.s3-ap-northeast-1.amazonaws.com/uploads/content_image/info.jpg", id: :img_prev, :size => '500x500'
-    end
+  def information_image
+    return image_tag "https://img-photo.s3-ap-northeast-1.amazonaws.com/uploads/content_image/info.jpg", id: :img_prev, :size => '500x500' if id == nil
+
+    info = Information.find(id)
+    return image_tag info.image.url, id: :img_prev, :size => '500x500' if info.image?
+    image_tag "https://img-photo.s3-ap-northeast-1.amazonaws.com/uploads/content_image/info.jpg", id: :img_prev, :size => '500x500'
   end
 end

--- a/app/decorators/relative_decorator.rb
+++ b/app/decorators/relative_decorator.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+module RelativeDecorator
+end

--- a/app/decorators/request_resident_decorator.rb
+++ b/app/decorators/request_resident_decorator.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+module RequestResidentDecorator
+end

--- a/app/decorators/reservation_decorator.rb
+++ b/app/decorators/reservation_decorator.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+module ReservationDecorator
+end

--- a/app/decorators/resident_decorator.rb
+++ b/app/decorators/resident_decorator.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module ResidentDecorator
-  def modal_title(content)
-    content.id.present? ? "入居者情報編集" : "入居者新規登録"
+  def modal_title
+    id.present? ? "入居者情報編集" : "入居者新規登録"
   end
 end

--- a/app/decorators/resident_decorator.rb
+++ b/app/decorators/resident_decorator.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module ResidentDecorator
+  def modal_title(content)
+    content.id.present? ? "入居者情報編集" : "入居者新規登録"
+  end
+end

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 module UserDecorator
-  # facility_idごとにグループ分けする
+  # facility_idごとにグループ分け
   def grouped_facility
     informations = Information.where(facility_id: current_user.facilities).where(status: "others")
     informations.group_by(&:facility_id)
   end
 
-  # 自分が登録している施設のお知らせで、statusがothersであるものを全て取得する
+  # 自分が登録している施設のお知らせで、statusがothersであるものを全て取得
   def mypage_informations(id)
     Information.where(facility_id: id).where(status: "others")
   end

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -21,7 +21,6 @@ module UserDecorator
 
   # お知らせiconを表示
   def mypage_informations_icon(id)
-    # facility = Facility.find(id)
     return image_tag id.image.url, class: "mypage-info-icon-image" if id.image?
     image_tag 'https://bulma.io/images/placeholders/128x128.png', class: "mypage-info-icon-image"
   end

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -25,4 +25,8 @@ module UserDecorator
     return image_tag id.image.url, class: "mypage-info-icon-image" if id.image?
     image_tag 'https://bulma.io/images/placeholders/128x128.png', class: "mypage-info-icon-image"
   end
+
+  def reservation_calendar
+    Reservation.where.not(calendar_day: nil)
+  end
 end

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module UserDecorator
+  # facility_idごとにグループ分けする
+  def grouped_facility
+    informations = Information.where(facility_id: current_user.facilities).where(status: "others")
+    informations.group_by(&:facility_id)
+  end
+
+  # 自分が登録している施設のお知らせで、statusがothersであるものを全て取得する
+  def mypage_informations(id)
+    Information.where(facility_id: id).where(status: "others")
+  end
+
+  # 施設のiconを表示
+  def mypage_informations_icon(id)
+    facility = Facility.find(id)
+    return image_tag facility.icon.url, class: "mypage-info-icon-image" if facility.icon?
+    image_tag 'https://img-photo.s3-ap-northeast-1.amazonaws.com/uploads/content_image/facility_default.png', class: "mypage-info-icon-image"
+  end
+end

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -12,10 +12,17 @@ module UserDecorator
     Information.where(facility_id: id).where(status: "others")
   end
 
-  # 施設のiconを表示
-  def mypage_informations_icon(id)
+  # 施設iconを表示
+  def mypage_facilities_icon(id)
     facility = Facility.find(id)
-    return image_tag facility.icon.url, class: "mypage-info-icon-image" if facility.icon?
-    image_tag 'https://img-photo.s3-ap-northeast-1.amazonaws.com/uploads/content_image/facility_default.png', class: "mypage-info-icon-image"
+    return image_tag facility.icon.url, class: "mypage-facility-icon-image" if facility.icon?
+    image_tag 'https://img-photo.s3-ap-northeast-1.amazonaws.com/uploads/content_image/facility_default.png', class: "mypage-facility-icon-image"
+  end
+
+  # お知らせiconを表示
+  def mypage_informations_icon(id)
+    # facility = Facility.find(id)
+    return image_tag id.image.url, class: "mypage-info-icon-image" if id.image?
+    image_tag 'https://bulma.io/images/placeholders/128x128.png', class: "mypage-info-icon-image"
   end
 end

--- a/app/helpers/facilities_helper.rb
+++ b/app/helpers/facilities_helper.rb
@@ -1,26 +1,2 @@
 module FacilitiesHelper
-  def facility_season_image(facility)
-    if facility.image?
-      image_tag facility.image.url, id: :img_prev, :size => '500x500'
-    else
-      month = Date.today.month
-      if month.in?([ 12, 1, 2 ])
-        image_tag 'https://img-photo.s3-ap-northeast-1.amazonaws.com/uploads/content_image/winter.jpg', id: :img_prev, :size => '500x500'
-      elsif month.in?([ 3, 4, 5 ])
-        image_tag 'https://img-photo.s3-ap-northeast-1.amazonaws.com/uploads/content_image/spring.jpg', id: :img_prev, :size => '500x500'
-      elsif month.in?([ 6, 7, 8 ])
-        image_tag 'https://img-photo.s3-ap-northeast-1.amazonaws.com/uploads/content_image/summer.jpg', id: :img_prev, :size => '500x500'
-      elsif month.in?([ 9, 10, 11 ])
-        image_tag 'https://img-photo.s3-ap-northeast-1.amazonaws.com/uploads/content_image/+autumn.jpg', id: :img_prev, :size => '500x500'
-      end
-    end
-  end
-
-  def facility_icon_image(facility)
-    if facility.icon?
-      image_tag facility.icon.url, id: :icon_prev, class: "icon_circle"
-    else
-      image_tag 'https://img-photo.s3-ap-northeast-1.amazonaws.com/uploads/content_image/facility_default.png', id: :icon_prev, class: "icon_circle"
-    end
-  end
 end

--- a/app/helpers/informations_helper.rb
+++ b/app/helpers/informations_helper.rb
@@ -1,26 +1,2 @@
 module InformationsHelper
-  def information_image(info)
-    if info.image?
-      image_tag info.image.url, id: :img_prev, :size => '500x500'
-    else
-      image_tag "https://img-photo.s3-ap-northeast-1.amazonaws.com/uploads/content_image/info.jpg", id: :img_prev, :size => '500x500'
-    end
-  end
-
-  # facility_idごとにグループ分けする
-  def grouped_facility(information)
-    information.group_by(&:facility_id)
-  end
-
-  # 施設のiconを表示
-  def mypage_informations_icon(id)
-    facility = Facility.find(id)
-    return image_tag facility.icon.url, class: "mypage-info-icon-image" if facility.icon?
-    image_tag 'https://img-photo.s3-ap-northeast-1.amazonaws.com/uploads/content_image/facility_default.png', class: "mypage-info-icon-image"
-  end
-
-  # 自分が登録している施設のお知らせで、statusがothersであるものを全て取得する
-  def mypage_informations(id)
-    Information.where(facility_id: id).where(status: "others")
-  end
 end

--- a/app/helpers/reservations_helper.rb
+++ b/app/helpers/reservations_helper.rb
@@ -1,5 +1,2 @@
 module ReservationsHelper
-  def calendar_reservation
-    Reservation.where.not(calendar_day: nil)
-  end
 end

--- a/app/helpers/residents_helper.rb
+++ b/app/helpers/residents_helper.rb
@@ -1,8 +1,4 @@
 module ResidentsHelper
-  def modal_title(content)
-    content.id.present? ? "入居者情報編集" : "入居者新規登録"
-  end
-
   def component(component_name, locals = {}, &block)
     render("residents/#{component_name}", locals, &block)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -33,6 +33,7 @@ class User < ApplicationRecord
   def remember_me
     true
   end
+
   # パスワード入力なしでご家族情報編集可能にするため追加
   def update_without_current_password(params, *options)
     params.delete(:current_password)

--- a/app/views/facilities/facility_home.html.erb
+++ b/app/views/facilities/facility_home.html.erb
@@ -78,7 +78,7 @@
         <div id="Web" class="content-tab" >
           <div class="has-text-centered" id="calendar-reservations">
             <div class="is-centered">
-              <%= month_calendar(attribute: :calendar_day, events: @calendar) do |date, reservations| %>
+              <%= month_calendar(attribute: :calendar_day, events: current_facility.reservation_calendar) do |date, reservations| %>
                 <%= l(date, format: :short) %>
               <% end %>
             </div><br>

--- a/app/views/facilities/facility_home.html.erb
+++ b/app/views/facilities/facility_home.html.erb
@@ -78,7 +78,7 @@
         <div id="Web" class="content-tab" >
           <div class="has-text-centered" id="calendar-reservations">
             <div class="is-centered">
-              <%= month_calendar(attribute: :calendar_day, events: calendar_reservation) do |date, reservations| %>
+              <%= month_calendar(attribute: :calendar_day, events: @calendar) do |date, reservations| %>
                 <%= l(date, format: :short) %>
               <% end %>
             </div><br>

--- a/app/views/facilities/registrations/edit.html.erb
+++ b/app/views/facilities/registrations/edit.html.erb
@@ -8,7 +8,7 @@
           <h1 class="mini-title" style="font-size: 20px; color: #401c00;">背景画像設定</h1>
           <p class="title-description">こちらから背景画像として使用される画像の登録・編集ができます。</p>
           <div class="facility-photo">
-          <%= current_facility.facility_season_image %>
+          <%= @facility.facility_season_image %>
           </div>
           <div class="drop-zone-area">
             <%= f.label :image, "\uf574", class: "fa image_input_comment_user", style: "margin-left: -15px;" %>
@@ -25,7 +25,7 @@
           <h1 class="mini-title" style="font-size: 20px; color: #401c00;">アイコン画像設定</h1>
           <p class="title-description">こちらからアイコンとして使用される画像の登録・編集ができます。</p>
           <div class="facility-photo">
-            <%= current_facility.facility_icon_image %>
+            <%= @facility.facility_icon_image %>
           </div>
           <div id="drop-zone-area"style="padding-left: 40px;">
             <%= f.label :icon, "\uf574", class: "fa image_input_comment_user" %>

--- a/app/views/facilities/registrations/edit.html.erb
+++ b/app/views/facilities/registrations/edit.html.erb
@@ -8,7 +8,7 @@
           <h1 class="mini-title" style="font-size: 20px; color: #401c00;">背景画像設定</h1>
           <p class="title-description">こちらから背景画像として使用される画像の登録・編集ができます。</p>
           <div class="facility-photo">
-          <%= facility_season_image(current_facility) %>
+          <%= current_facility.facility_season_image(current_facility) %>
           </div>
           <div class="drop-zone-area">
             <%= f.label :image, "\uf574", class: "fa image_input_comment_user", style: "margin-left: -15px;" %>
@@ -25,7 +25,7 @@
           <h1 class="mini-title" style="font-size: 20px; color: #401c00;">アイコン画像設定</h1>
           <p class="title-description">こちらからアイコンとして使用される画像の登録・編集ができます。</p>
           <div class="facility-photo">
-            <%= facility_icon_image(current_facility) %>
+            <%= current_facility.facility_icon_image(current_facility) %>
           </div>
           <div id="drop-zone-area"style="padding-left: 40px;">
             <%= f.label :icon, "\uf574", class: "fa image_input_comment_user" %>

--- a/app/views/facilities/registrations/edit.html.erb
+++ b/app/views/facilities/registrations/edit.html.erb
@@ -8,7 +8,7 @@
           <h1 class="mini-title" style="font-size: 20px; color: #401c00;">背景画像設定</h1>
           <p class="title-description">こちらから背景画像として使用される画像の登録・編集ができます。</p>
           <div class="facility-photo">
-          <%= current_facility.facility_season_image(current_facility) %>
+          <%= current_facility.facility_season_image %>
           </div>
           <div class="drop-zone-area">
             <%= f.label :image, "\uf574", class: "fa image_input_comment_user", style: "margin-left: -15px;" %>
@@ -25,7 +25,7 @@
           <h1 class="mini-title" style="font-size: 20px; color: #401c00;">アイコン画像設定</h1>
           <p class="title-description">こちらからアイコンとして使用される画像の登録・編集ができます。</p>
           <div class="facility-photo">
-            <%= current_facility.facility_icon_image(current_facility) %>
+            <%= current_facility.facility_icon_image %>
           </div>
           <div id="drop-zone-area"style="padding-left: 40px;">
             <%= f.label :icon, "\uf574", class: "fa image_input_comment_user" %>

--- a/app/views/facility_users/new.html.erb
+++ b/app/views/facility_users/new.html.erb
@@ -40,7 +40,7 @@
                   <div class="card card-style" style="position: relative;">
                     <div class="card-image">
                       <figure class="image">
-                        <%= facility_season_image(fa) %>
+                        <%= fa.facility_season_image(fa) %>
                       </figure>
                     </div>
                     <div class="card-content">
@@ -118,11 +118,11 @@
                 <% if current_user.facilities.blank? %>
                   <p class="title is-6 result">現在の登録施設はありません。</p>
                 <% end %>
-                <% current_user.facilities.each do |fa| %>
+                <% @registered_facilities.each do |fa| %>
                   <div class="card card-style">
                     <div class="card-image">
                       <figure class="image">
-                        <%= facility_season_image(fa) %>
+                        <%= fa.facility_season_image(fa) %>
                       </figure>
                     </div>
                     <div class="card-content">

--- a/app/views/facility_users/new.html.erb
+++ b/app/views/facility_users/new.html.erb
@@ -40,7 +40,7 @@
                   <div class="card card-style" style="position: relative;">
                     <div class="card-image">
                       <figure class="image">
-                        <%= fa.facility_season_image(fa) %>
+                        <%= fa.facility_season_image %>
                       </figure>
                     </div>
                     <div class="card-content">
@@ -122,7 +122,7 @@
                   <div class="card card-style">
                     <div class="card-image">
                       <figure class="image">
-                        <%= fa.facility_season_image(fa) %>
+                        <%= fa.facility_season_image %>
                       </figure>
                     </div>
                     <div class="card-content">

--- a/app/views/informations/edit.html.erb
+++ b/app/views/informations/edit.html.erb
@@ -10,7 +10,7 @@
           <%= form_with(model: @information, url: information_path, method: :patch, local: true) do |f| %>
             <%= render partial: 'shared/error_messages', locals: { obj: @information } %>
             <div class="label-space">
-              <%= information_image(@information) %>
+              <%= @information.information_image(@information) %>
             </div>
             <div class="drop-zone-area">
               <%= f.label :image, "\uf574", class: "fa image_input_comment" %>

--- a/app/views/informations/edit.html.erb
+++ b/app/views/informations/edit.html.erb
@@ -10,7 +10,7 @@
           <%= form_with(model: @information, url: information_path, method: :patch, local: true) do |f| %>
             <%= render partial: 'shared/error_messages', locals: { obj: @information } %>
             <div class="label-space">
-              <%= @information.information_image(@information) %>
+              <%= @information.information_image %>
             </div>
             <div class="drop-zone-area">
               <%= f.label :image, "\uf574", class: "fa image_input_comment" %>

--- a/app/views/informations/new.html.erb
+++ b/app/views/informations/new.html.erb
@@ -10,7 +10,7 @@
           <%= form_with(model: @information, url: informations_path, method: :post, local: true) do |f| %>
             <%= render partial: 'shared/error_messages', locals: { obj: @information } %>
             <div class="label-space">
-              <%= information_image(@information) %>
+              <%= @information.information_image(@information) %>
             </div>
             <div class="drop-zone-area">
               <%= f.label :image, "\uf574", class: "fa image_input_comment" %>

--- a/app/views/informations/new.html.erb
+++ b/app/views/informations/new.html.erb
@@ -10,7 +10,7 @@
           <%= form_with(model: @information, url: informations_path, method: :post, local: true) do |f| %>
             <%= render partial: 'shared/error_messages', locals: { obj: @information } %>
             <div class="label-space">
-              <%= @information.information_image(@information) %>
+              <%= @information.information_image %>
             </div>
             <div class="drop-zone-area">
               <%= f.label :image, "\uf574", class: "fa image_input_comment" %>

--- a/app/views/residents/_form.html.erb
+++ b/app/views/residents/_form.html.erb
@@ -1,5 +1,5 @@
 <header class="modal-card-head" style="background-color: #48D1CC;">
-  <p class="modal-card-title is-half has-text-weight-bold reserve-modal is-size-3"><%= @resident.modal_title(content) %></p>
+  <p class="modal-card-title is-half has-text-weight-bold reserve-modal is-size-3"><%= @resident.modal_title %></p>
 </header>
 <section class="modal-card-body">
   <div class="field">

--- a/app/views/residents/_form.html.erb
+++ b/app/views/residents/_form.html.erb
@@ -1,5 +1,5 @@
 <header class="modal-card-head" style="background-color: #48D1CC;">
-  <p class="modal-card-title is-half has-text-weight-bold reserve-modal is-size-3"><%= modal_title(content) %></p>
+  <p class="modal-card-title is-half has-text-weight-bold reserve-modal is-size-3"><%= @resident.modal_title(content) %></p>
 </header>
 <section class="modal-card-body">
   <div class="field">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -63,7 +63,7 @@
           <div class="card" id="mypage-reservations-calendar">
             <div class="has-text-centered">
               <div class="is-centered">
-                <%= month_calendar(attribute: :calendar_day, events: @calendar) do |date, reservations| %>
+                <%= month_calendar(attribute: :calendar_day, events: current_user.reservation_calendar) do |date, reservations| %>
                   <%= l(date, format: :short) %>
                 <% end %>
               </div><br>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -29,7 +29,7 @@
               <div class="card-content" id="my-page-info-content">
                 <div class="card" style="display: flex; border-radius: 11px;">
                   <div class="media-left">
-                    <small><%= current_user.mypage_informations_icon(facility_id) %></small>
+                    <small><%= current_user.mypage_facilities_icon(facility_id) %></small>
                   </div>
                   <div class="media-content" id="web-media-section">
                     <% current_user.mypage_informations(facility_id).last(2).each do |information| %>
@@ -37,16 +37,14 @@
                       <div>
                         <div class="box" id="mypage-user-box">
                           <div class="media">
-                              <figure class="image is-64x64" style="margin-right: 10px;">
-                                <img src="https://bulma.io/images/placeholders/128x128.png" alt="Image">
-                              </figure>
+                            <%= current_user.mypage_informations_icon(information) %>
                             <div class="media-content">
                               <div class="content" id="edit-content">
                                 <p class="is-size-7">
-                                <strong><%= information.title.truncate(14) %></strong><br>
+                                <strong><%= information.title.truncate(9) %></strong><br>
                                   <small><%= information.facility.facility_name %></small>
                                   <br>
-                                  <span><%= information.news.truncate(13) %></span>
+                                  <span><%= information.news.truncate(10) %></span>
                                 </p>
                               </div>
                             </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -25,14 +25,14 @@
       <div id="Web" class="content-tab">
         <div class="Web-section">
           <div class="columns">
-            <% grouped_facility(@informations).each do |facility_id, other| %>
+            <% current_user.grouped_facility.each do |facility_id, other| %>
               <div class="card-content" id="my-page-info-content">
                 <div class="card" style="display: flex; border-radius: 11px;">
                   <div class="media-left">
-                    <small><%= mypage_informations_icon(facility_id) %></small>
+                    <small><%= current_user.mypage_informations_icon(facility_id) %></small>
                   </div>
                   <div class="media-content" id="web-media-section">
-                    <% mypage_informations(facility_id).last(2).each do |information| %>
+                    <% current_user.mypage_informations(facility_id).last(2).each do |information| %>
                     <div class="mypage-information">
                       <div>
                         <div class="box" id="mypage-user-box">
@@ -65,7 +65,7 @@
           <div class="card" id="mypage-reservations-calendar">
             <div class="has-text-centered">
               <div class="is-centered">
-                <%= month_calendar(attribute: :calendar_day, events: calendar_reservation) do |date, reservations| %>
+                <%= month_calendar(attribute: :calendar_day, events: @calendar) do |date, reservations| %>
                   <%= l(date, format: :short) %>
                 <% end %>
               </div><br>

--- a/test/decorators/facility_decorator_test.rb
+++ b/test/decorators/facility_decorator_test.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class FacilityDecoratorTest < ActiveSupport::TestCase
+  def setup
+    @facility = Facility.new.extend FacilityDecorator
+  end
+
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/decorators/facility_user_decorator_test.rb
+++ b/test/decorators/facility_user_decorator_test.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class FacilityUserDecoratorTest < ActiveSupport::TestCase
+  def setup
+    @facility_user = FacilityUser.new.extend FacilityUserDecorator
+  end
+
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/decorators/information_decorator_test.rb
+++ b/test/decorators/information_decorator_test.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class InformationDecoratorTest < ActiveSupport::TestCase
+  def setup
+    @information = Information.new.extend InformationDecorator
+  end
+
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/decorators/relative_decorator_test.rb
+++ b/test/decorators/relative_decorator_test.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class RelativeDecoratorTest < ActiveSupport::TestCase
+  def setup
+    @relative = Relative.new.extend RelativeDecorator
+  end
+
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/decorators/request_resident_decorator_test.rb
+++ b/test/decorators/request_resident_decorator_test.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class RequestResidentDecoratorTest < ActiveSupport::TestCase
+  def setup
+    @request_resident = RequestResident.new.extend RequestResidentDecorator
+  end
+
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/decorators/reservation_decorator_test.rb
+++ b/test/decorators/reservation_decorator_test.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ReservationDecoratorTest < ActiveSupport::TestCase
+  def setup
+    @reservation = Reservation.new.extend ReservationDecorator
+  end
+
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/decorators/resident_decorator_test.rb
+++ b/test/decorators/resident_decorator_test.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ResidentDecoratorTest < ActiveSupport::TestCase
+  def setup
+    @resident = Resident.new.extend ResidentDecorator
+  end
+
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/decorators/user_decorator_test.rb
+++ b/test/decorators/user_decorator_test.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class UserDecoratorTest < ActiveSupport::TestCase
+  def setup
+    @user = User.new.extend UserDecorator
+  end
+
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## Issueへのリンク
* https://github.com/hayaminahiro/family_online_visit/issues/104#issue-738237816

## 実装内容
・active_decoraterを追加してファイルを新規作成
・ヘルパーの内容をデコレータに移植する
・ご家族マイページ、各お知らせの画像を表示できるようにした

## やらないこと

## できるようになること（ユーザ目線）

## できなくなること（ユーザ目線）
## 動作確認
◯ヘルパーに書かれていた内容をデコレータに移植してエラーなく動くことを確認した
確認ページ↓
・ご家族マイページ
・お知らせ新規作成・編集ページ
・施設情報編集ページ
・入居者新規作成・入居者編集モーダル
・カレンダー表示部分（施設側ホーム画面・ご家族マイページ）

## その他
### 【デコレータ追加した際に詰まったところ２点】
◯ヘルパーの時のようにメソッド名単体では扱えないみたいです
例）
```rb
<%= information_image(@information) %>　# これだとエラー
                  ↓↓
<%= @information.information_image %>
```

◯特定のデコレーターファイルに記述しないとエラーがでる
　→ヘルパーの場合どこのファイルに記述しても動いてくれてたが、記述するファイルを間違えると`undefined method error`が出て、定義されていないとなる

## 参考
・acitive_decorater↓
https://github.com/amatsuda/active_decorator

・デコレータが使われているアプリ（どんな感じで使えるかの参考）
https://github.com/shotaimai66/new_reserve_app

