### PR TITLE
search部分の処理をモデルに移動　Feature/#116 fix index action

### DIFF
--- a/app/controllers/facilities_controller.rb
+++ b/app/controllers/facilities_controller.rb
@@ -7,8 +7,7 @@ class FacilitiesController < ApplicationController
   before_action :index_access_limits, only: :index
 
   def index
-    return @facilities = Facility.where('facility_name LIKE ?', "%#{params[:search]}%").paginate(page: params[:page], per_page: 30).order(:id) if params[:search].present?
-    @facilities = Facility.where.not(admin: true).paginate(page: params[:page], per_page: 30).order(:id)
+    @facilities = Facility.search(params[:search]).paginate(page: params[:page], per_page: 30)
   end
 
   def home #各施設のホーム画面

--- a/app/controllers/facilities_controller.rb
+++ b/app/controllers/facilities_controller.rb
@@ -15,12 +15,6 @@ class FacilitiesController < ApplicationController
   end
 
   def facility_home  #施設ルートのhome画面
-    @facilities = Facility.all.where.not(admin: true)
-    @registration_application = @facilities.where(id: current_facility.users)
-    @users = @facility.users.paginate(page: params[:page], per_page: 30).order(:id)
-    if params[:search].present?
-      @users = @users.where('name LIKE ?', "%#{params[:search]}%").paginate(page: params[:page], per_page: 30).order(:id)
-    end
     @info_top = Information.find_by(status: "head")
     @request_residents = RequestResident.where(req_approval: "申請中").where(facility_id: current_facility)
   end

--- a/app/controllers/facility_users_controller.rb
+++ b/app/controllers/facility_users_controller.rb
@@ -1,9 +1,7 @@
 class FacilityUsersController < ApplicationController
   def new
-    @facility_users = Facility.all.where.not(admin: true)
     @registered_facilities = current_user.facilities
-    return @facility_users = @facility_users.where('facility_name LIKE ?', "%#{params[:search]}%").where.not(id: current_user.facilities).paginate(page: params[:page], per_page: 12).order(:id) if params[:search].present?
-    @facility_users = @facility_users.where('facility_name LIKE ?', "")
+    @facility_users = FacilityUser.search(params[:search], Facility.all, current_user).paginate(page: params[:page], per_page: 12)
   end
 
   def update

--- a/app/controllers/informations_controller.rb
+++ b/app/controllers/informations_controller.rb
@@ -6,10 +6,7 @@ class InformationsController < ApplicationController
 
   def index
     @info_top = Information.find_by(status: "head")
-    @information = Information.new
-
-    return @informations = current_facility.informations.where(status: "others").where('title LIKE ?', "%#{params[:search]}%").paginate(page: params[:page], per_page: 9).order(id: "DESC") if params[:search].present?
-    @informations = current_facility.informations.where(status: "others").order(id: "DESC").paginate(page: params[:page], per_page: 9)
+    @informations = Information.search(params[:search], current_facility).paginate(page: params[:page], per_page: 9)
   end
 
   def show;end

--- a/app/controllers/relatives_controller.rb
+++ b/app/controllers/relatives_controller.rb
@@ -1,7 +1,6 @@
 class RelativesController < ApplicationController
   def new #家族から申請された内容を確認
-    return @residents = current_facility.residents.where('name LIKE ?', "%#{params[:search]}%").paginate(page: params[:page], per_page: 9).order(:id) if params[:search].present?
-    @residents = current_facility.residents.where('name LIKE ?', "")
+    @residents = Relative.search(params[:search], current_facility).paginate(page: params[:page], per_page: 9)
   end
 
   def update #家族からの申請を承認・否認

--- a/app/controllers/residents_controller.rb
+++ b/app/controllers/residents_controller.rb
@@ -2,8 +2,7 @@ class ResidentsController < ApplicationController
   before_action :set_resident, only: %i[edit update destroy]
 
   def index
-    return @residents = current_facility.residents.where('name LIKE ?', "%#{params[:search]}%").paginate(page: params[:page], per_page: 30).order(:id) if params[:search].present?
-    @residents = current_facility.residents.paginate(page: params[:page], per_page: 30)
+    @residents = Resident.search(params[:search], current_facility).paginate(page: params[:page], per_page: 30)
   end
 
   def new

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,8 +6,7 @@ class UsersController < ApplicationController
   before_action :authenticate_facility!, only: %i[room_word_update index video_room edit update destroy]
 
   def index
-    return @users = current_facility.users.where('name LIKE ?', "%#{params[:search]}%").paginate(page: params[:page], per_page: 30).order(:id) if params[:search].present?
-    @users = current_facility.users.paginate(page: params[:page], per_page: 30).order(:id)
+    @users = User.search(params[:search], current_facility).paginate(page: params[:page], per_page: 30)
   end
 
   def room_word_update

--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -25,6 +25,6 @@ class Facility < ApplicationRecord
     def self.search(search)
       return where.not(admin: true).order(:id) unless search
 
-      where('facility_name LIKE ?', "%#{search}%").order(:id)
+      where('facility_name LIKE ?', "%#{search}%").where.not(admin: true).order(:id)
     end
 end

--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -20,4 +20,11 @@ class Facility < ApplicationRecord
   # モデル | ImageUploaderクラスとimageカラムを紐づける
   mount_uploader :image, ImageUploader
   mount_uploader :icon, ImageUploader
+
+    #search定義
+    def self.search(search)
+      return where.not(admin: true).order(:id) unless search
+
+      where('facility_name LIKE ?', "%#{search}%").order(:id)
+    end
 end

--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -23,8 +23,7 @@ class Facility < ApplicationRecord
 
     #search定義
     def self.search(search)
-      return where.not(admin: true).order(:id) unless search
-
+      where.not(admin: true).order(:id) unless search
       where('facility_name LIKE ?', "%#{search}%").where.not(admin: true).order(:id)
     end
 end

--- a/app/models/facility_user.rb
+++ b/app/models/facility_user.rb
@@ -5,8 +5,8 @@ class FacilityUser < ApplicationRecord
 
   #search定義
   def self.search(search, all, user)
-    return all.where('facility_name LIKE ?', "").where.not(admin: true) unless search
+    return all.where(['facility_name LIKE ?', "%#{search}%"]).where.not(admin: true, id: user.facilities).order(:id) if search.present?
 
-    all.where('facility_name LIKE ?', "%#{search}%").where.not(admin: true, id: user.facilities).order(:id)
+    all.where('facility_name LIKE ?', "").where.not(admin: true)
   end
 end

--- a/app/models/facility_user.rb
+++ b/app/models/facility_user.rb
@@ -2,4 +2,11 @@ class FacilityUser < ApplicationRecord
   # optional: trueは、外部キーのnilを許可
   belongs_to :user, optional: true
   belongs_to :facility, optional: true
+
+  #search定義
+  def self.search(search, all, user)
+    return all.where('facility_name LIKE ?', "").where.not(admin: true) unless search
+
+    all.where('facility_name LIKE ?', "%#{search}%").where.not(admin: true, id: user.facilities).order(:id)
+  end
 end

--- a/app/models/information.rb
+++ b/app/models/information.rb
@@ -8,4 +8,11 @@ class Information < ApplicationRecord
 
   # モデル | ImageUploaderクラスとimageカラムを紐づける
   mount_uploader :image, ImageUploader
+
+  #search定義
+  def self.search(search, facility)
+    return facility.informations.where(status: "others").order(id: "DESC") unless search
+
+    facility.informations.where(status: "others").where('title LIKE ?', "%#{search}%").order(id: "DESC")
+  end
 end

--- a/app/models/information.rb
+++ b/app/models/information.rb
@@ -11,8 +11,7 @@ class Information < ApplicationRecord
 
   #search定義
   def self.search(search, facility)
-    return facility.informations.where(status: "others").order(id: "DESC") unless search
-
+    facility.informations.where(status: "others").order(id: "DESC") unless search
     facility.informations.where(status: "others").where('title LIKE ?', "%#{search}%").order(id: "DESC")
   end
 end

--- a/app/models/relative.rb
+++ b/app/models/relative.rb
@@ -1,4 +1,11 @@
 class Relative < ApplicationRecord
   belongs_to :user
   belongs_to :resident
+
+  #search定義
+  def self.search(search, facility)
+    return facility.residents.where('name LIKE ?', "") unless search
+
+    facility.residents.where('name LIKE ?', "%#{search}%").order(:id)
+  end
 end

--- a/app/models/relative.rb
+++ b/app/models/relative.rb
@@ -4,8 +4,8 @@ class Relative < ApplicationRecord
 
   #search定義
   def self.search(search, facility)
-    return facility.residents.where('name LIKE ?', "") unless search
+    return facility.residents.where('name LIKE ?', "%#{search}%").order(:id) if search.present?
 
-    facility.residents.where('name LIKE ?', "%#{search}%").order(:id)
+    facility.residents.where('name LIKE ?', "")
   end
 end

--- a/app/models/resident.rb
+++ b/app/models/resident.rb
@@ -6,4 +6,11 @@ class Resident < ApplicationRecord
 
   validates :name, presence: true, length: { maximum: 20 }
   validates :charge_worker, presence: true, length: { maximum: 20 }
+
+  #search定義
+  def self.search(search, facility)
+    return facility.residents.includes(:users) unless search
+
+    facility.residents.includes(:users).where('name LIKE ?', "%#{search}%").order(:id)
+  end
 end

--- a/app/models/resident.rb
+++ b/app/models/resident.rb
@@ -9,8 +9,7 @@ class Resident < ApplicationRecord
 
   #search定義
   def self.search(search, facility)
-    return facility.residents.includes(:users) unless search
-
+    facility.residents.includes(:users) unless search
     facility.residents.includes(:users).where('name LIKE ?', "%#{search}%").order(:id)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -64,4 +64,11 @@ class User < ApplicationRecord
     self.raw_info = raw_info.to_json
     self.save!
   end
+
+  #search定義
+  def self.search(search, facility)
+    return facility.users unless search
+
+    facility.users.where('name LIKE ?', "%#{search}%").order(:id)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -67,8 +67,7 @@ class User < ApplicationRecord
 
   #search定義
   def self.search(search, facility)
-    return facility.users unless search
-
+    facility.users unless search
     facility.users.where('name LIKE ?', "%#{search}%").order(:id)
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -58,6 +58,13 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
-  BetterErrors::Middleware.allow_ip! "0.0.0.0/0"  #BetterErrorsをdockerで使用の場合に追加
-  config.web_console.whitelisted_ips = %w( 0.0.0.0/0 ::/0 ) #web_consoleをdockerで使用の場合に追加
+  BetterErrors::Middleware.allow_ip! "0.0.0.0/0" # BetterErrorsをdockerで使用の場合に追加
+  config.web_console.whitelisted_ips = %w[0.0.0.0/0 ::/0] # web_consoleをdockerで使用の場合に追加
+  config.after_initialize do
+    Bullet.enable = true # Bulletプラグインを有効
+    Bullet.alert = true # JavaScriptでの通知
+    Bullet.bullet_logger = true # log/bullet.logへの出力
+    Bullet.console = true # ブラウザのコンソールログに記録
+    Bullet.rails_logger = true # Railsログに出力
+  end
 end


### PR DESCRIPTION
## 実装内容
・各コントローラ「search部分」の処理をモデルに移動し、コントローラの記述を減らした。
・includesを使用してN＋１問題発生箇所の修正→　https://github.com/hayaminahiro/family_online_visit/commit/7ca8f1946c3134be85eef5c4245daee7c125c617
・facilitiesコントローラで使われていないインスタンス変数を削除→　https://github.com/hayaminahiro/family_online_visit/commit/82bfe4e5fc30fdca2fecb88b08c444a10a74e5c6
・bulletが機能するようにコードを追加→　https://github.com/hayaminahiro/family_online_visit/commit/b268223d2021a546644207fc036e5170ae3bd27e


## やらないこと

## できるようになること（ユーザ目線）
* なし

## できなくなること（ユーザ目線）
* なし

## 動作確認
* 変更箇所の動作確認をしながら修正しましたがご確認お願い致します💦

## その他





## 画像
