### PR TITLE
申請機能の修正 Feature/#140 fix resident relatives

### DIFF
--- a/app/assets/stylesheets/relatives.scss
+++ b/app/assets/stylesheets/relatives.scss
@@ -60,7 +60,17 @@
     position: relative;
     margin: auto;
     margin: 0px auto;
-    margin-top: 20px;
+    margin-bottom: 25px;
+  }
+
+  .request-time{
+    text-align: right;
+    width: 97%;
+    color: gray;
+
+    span{
+      margin-right: 10px;
+    }
   }
 }
 
@@ -433,7 +443,7 @@
     position: relative;
     margin: auto;
     margin: 0px auto;
-    margin-top: 20px;
+    margin-bottom: 20px;
     width: 80%;
   }
 
@@ -448,6 +458,16 @@
     font-size: 18px;
     font-weight: 600;
     margin-right: 10px;
+  }
+
+  .request-time{
+    text-align: right;
+    width: 90%;
+    color: gray;
+
+    span{
+      margin-right: 10px;
+    }
   }
 }
 
@@ -579,6 +599,15 @@
     width: 150px; border: solid 1px;
     font-size: initial;
     font-weight: 500;
+  }
+
+  .request-time{
+    text-align: right;
+    color: gray;
+
+    span{
+      margin-right: 10px;
+    }
   }
 }
 

--- a/app/assets/stylesheets/request_residents.scss
+++ b/app/assets/stylesheets/request_residents.scss
@@ -85,6 +85,10 @@
     display: block;
     padding: 15px;
   }
+
+  p span{
+    font-size: 18px;
+  }
 }
 
 #req-edit-tfoot{

--- a/app/controllers/relatives_controller.rb
+++ b/app/controllers/relatives_controller.rb
@@ -29,9 +29,9 @@ class RelativesController < ApplicationController
     residents_connection_params.each do |id, item|
       request_user = User.find(id)
       req_resident = RequestResident.changer(current_facility, id)
-      unless item[:resident_ids].map(&:to_i).reject(&:zero?).count == request_user.resident_ids.count
-        req_resident.approval!
+      unless item[:resident_ids].map(&:to_i).reject(&:zero?).sort == request_user.resident_ids.sort
         request_user.update_attributes(item)
+        req_resident.approval!
       end
     end
     redirect_to facility_home_facility_url(current_facility), notice: "まとめて承認しました。"

--- a/app/decorators/facility_decorator.rb
+++ b/app/decorators/facility_decorator.rb
@@ -96,7 +96,8 @@ module FacilityDecorator
     r_ids[:resident_ids].map(&:to_i).reject(&:zero?)
   end
 
-  def resident_name(id)
-    Resident.find(id).name
+  def resident_name(resident_id)
+    resident = Resident.find(resident_id)
+    resident.name if resident.facility_id == id
   end
 end

--- a/app/decorators/request_resident_decorator.rb
+++ b/app/decorators/request_resident_decorator.rb
@@ -22,4 +22,8 @@ module RequestResidentDecorator
       tag.p((link_to "ご利用者様の登録申請", new_request_resident_path(facility_id: facility), class: "btn-shine"))
     end
   end
+
+  def exclude_ids
+    Resident.all.where.not(facility_id: current_facility.id)
+  end
 end

--- a/app/views/facilities/facility_home.html.erb
+++ b/app/views/facilities/facility_home.html.erb
@@ -49,7 +49,7 @@
                   <% @request_residents.each do |request_resident| %>
                   <% @request_user = User.find(request_resident.user_id) %>
                     <tr>
-                      <td><%= request_resident.created_at %></td>
+                      <td><%= l(request_resident.created_at, format: :long) %></td>
                       <td><%= @request_user.name %></td>
                       <td>
                         <%= link_to "申請者登録画面", relative_path(request_resident), class: "button is-primary is-small has-text-weight-bold is-size-6", style: "width: 45%;" %>

--- a/app/views/relatives/_relative_modal_contents.html.erb
+++ b/app/views/relatives/_relative_modal_contents.html.erb
@@ -19,7 +19,7 @@
       <% applied.user.request_residents.order(id: :desc).each do |request| %>
         <% if request.facility_id == current_facility.id %>
           <div class="relative-modal-contents">
-            <span class="w-15"><%= l(request.created_at, format: :dot) %></span>
+            <span class="w-15"><%= l(request.created_at, format: :long) %></span>
             <span class="w-15"><%= request.status %></span>
             <span class="w-30"><%= simple_format(request.req_name) %></span>
             <span class="w-15"><%= simple_format(request.req_phone) %></span>

--- a/app/views/relatives/_relative_modal_contents.html.erb
+++ b/app/views/relatives/_relative_modal_contents.html.erb
@@ -17,13 +17,15 @@
       </div>
 
       <% applied.user.request_residents.order(id: :desc).each do |request| %>
-        <div class="relative-modal-contents">
-          <span class="w-15"><%= l(request.created_at, format: :dot) %></span>
-          <span class="w-15"><%= request.status %></span>
-          <span class="w-30"><%= simple_format(request.req_name) %></span>
-          <span class="w-15"><%= simple_format(request.req_phone) %></span>
-          <span class="w-30"><%= simple_format(request.req_address) %></span><br>
-        </div>
+        <% if request.facility_id == current_facility.id %>
+          <div class="relative-modal-contents">
+            <span class="w-15"><%= l(request.created_at, format: :dot) %></span>
+            <span class="w-15"><%= request.status %></span>
+            <span class="w-30"><%= simple_format(request.req_name) %></span>
+            <span class="w-15"><%= simple_format(request.req_phone) %></span>
+            <span class="w-30"><%= simple_format(request.req_address) %></span><br>
+          </div>
+        <% end %>
       <% end %>
 
       </div><br>

--- a/app/views/relatives/_relative_modal_contents.html.erb
+++ b/app/views/relatives/_relative_modal_contents.html.erb
@@ -9,7 +9,7 @@
       <div class="form-group col-sm-5">
 
       <div class="relative-modal-title">
-        <p class="w-15">日付</p>
+        <p class="w-15">申請日</p>
         <p class="w-15">承認/否認</p>
         <p class="w-30">入居者名</p>
         <p class="w-15">電話番号</p>

--- a/app/views/relatives/confirm.html.erb
+++ b/app/views/relatives/confirm.html.erb
@@ -47,7 +47,7 @@
                     <p>↓↓</p>
 
                     <p class="is-size-7">（承認後の入居者）</p>
-                    <% if current_facility.newly_numbers(r_ids).count == request.user.residents.where(facility_id: current_facility.id).count %>
+                    <% if current_facility.newly_numbers(r_ids).sort == request.user.resident_ids.sort %>
                       <p class="c-red has-text-weight-bold">申請を保留します</p>
                     <% else %>
                       <% current_facility.newly_numbers(r_ids).each do |r_id| %>

--- a/app/views/relatives/confirm.html.erb
+++ b/app/views/relatives/confirm.html.erb
@@ -1,6 +1,7 @@
 <div class="relative-confirm-body">
   <% @request_residents.each do |user, r_ids| %>
     <% current_facility.acceptance_requests(user).each do |request| %>
+      <div class="request-time"><span>申請日</span><%= l(request.created_at, format: :long) %></div>
       <div class="card">
         <div class="relative-new-container">
           <div class="relative-confirm-section">

--- a/app/views/relatives/confirm.html.erb
+++ b/app/views/relatives/confirm.html.erb
@@ -35,18 +35,18 @@
                   <th>紐付け</th>
                   <td>
                     <p class="is-size-7">（登録済み入居者）</p>
-                    <% if request.user.residents == [] %>
-                      <p class="registered-name">現在登録されている利用者はいません</p><br>
-                    <% else %>
+                    <% if request.user.residents.map(&:facility_id).include?(current_facility.id) %>
                       <% request.user.residents.each do |resident| %>
-                        <span class="registered-name"><%= resident.name %></span>
+                        <span class="registered-name"><%= resident.name if resident.facility_id == current_facility.id %></span>
                       <% end %><br><br>
+                    <% else %>
+                      <p class="registered-name">現在登録されている利用者はいません</p><br>
                     <% end %>
 
                     <p>↓↓</p>
 
                     <p class="is-size-7">（承認後の入居者）</p>
-                    <% if current_facility.newly_numbers(r_ids).count == request.user.residents.count %>
+                    <% if current_facility.newly_numbers(r_ids).count == request.user.residents.where(facility_id: current_facility.id).count %>
                       <p class="c-red has-text-weight-bold">申請を保留します</p>
                     <% else %>
                       <% current_facility.newly_numbers(r_ids).each do |r_id| %>

--- a/app/views/relatives/edit.html.erb
+++ b/app/views/relatives/edit.html.erb
@@ -3,7 +3,7 @@
     <div class="relative-section">
       <nav class="relative-level">
         <div class="new-c-container">
-          <%= form_with(url: relative_path(@request), method: :get, local: true) do |f| %>
+          <%= form_with(url: edit_relative_path(@request), method: :get, local: true) do |f| %>
             <div class="field is-grouped is-grouped-right">
               <div class="control has-icons-left">
                 <%= f.text_field :search, :placeholder => "利用者名を入力..", class: "input is-rounded" %>

--- a/app/views/relatives/edit.html.erb
+++ b/app/views/relatives/edit.html.erb
@@ -18,6 +18,8 @@
           <% end %>
         </div>
       </nav>
+
+      <div class="request-time"><span>申請日</span><%= l(@request.created_at, format: :long) %></div>
       <div class="card">
         <table class="table is-narrow user-edit-table is-bordered mb-30" id="relative-table">
           <tbody>

--- a/app/views/relatives/edit.html.erb
+++ b/app/views/relatives/edit.html.erb
@@ -63,6 +63,12 @@
                       <span class="r-check-box"><%= b.label { b.check_box + " " + b.text } %></span>
                     <% end %><br>
                   </div>
+                  <div class="d-none">
+                    <%= f.collection_check_boxes :resident_ids, @request.exclude_ids, :id, :name do |b| %>
+                      <span class="r-check-box"><%= b.label { b.check_box + " " + b.text } %></span>
+                    <% end %>
+                  </div>
+
                   <div class="tag-apply">
                     <%= f.collection_check_boxes :resident_ids, @user.residents, :id, :name, class: 'd-none' do |b| %>
                       <% if b.object.facility_id == current_facility.id  %>

--- a/app/views/relatives/edit.html.erb
+++ b/app/views/relatives/edit.html.erb
@@ -63,7 +63,9 @@
                   </div>
                   <div class="tag-apply">
                     <%= f.collection_check_boxes :resident_ids, @user.residents, :id, :name, class: 'd-none' do |b| %>
-                      <span class="tag is-warning r-tag"><%= b.label { b.text } %>承認済</span>
+                      <% if b.object.facility_id == current_facility.id  %>
+                        <span class="tag is-warning r-tag"><%= b.label { b.text } %>承認済</span>
+                      <% end %>
                     <% end %>
                   </div>
                   <div class="propriety">

--- a/app/views/relatives/index.html.erb
+++ b/app/views/relatives/index.html.erb
@@ -36,7 +36,7 @@
       <% @applied_ids.group_by(&:user_id).each do |applied_id, applied| %>
         <tr>
           <td>
-          <%= l(applied[0].created_at, format: :dot) %>
+          <%= l(applied[0].created_at, format: :long) %>
           </td>
           <td>
             <p><%= applied[0].user.name %></p>

--- a/app/views/relatives/new.html.erb
+++ b/app/views/relatives/new.html.erb
@@ -16,11 +16,10 @@
   <%= form_with(model: current_facility, url: confirm_relative_path(current_facility), local: true) do |f| %>
     <% @requests.each do |request| %>
       <% if request.req_approval == "request" %>
+        <div class="request-time"><span>申請日</span><%= l(request.created_at, format: :long) %></div>
         <div class="card">
           <div class="relative-new-container">
             <div class="relative-new-section">
-            <nav class="level" id="level-bottom">
-            </nav>
               <table class="table is-narrow user-edit-table is-bordered" id="relative-table">
                 <tbody>
                   <tr>

--- a/app/views/relatives/new.html.erb
+++ b/app/views/relatives/new.html.erb
@@ -73,7 +73,9 @@
                       </div>
                       <div class="tag-apply">
                         <%= i.collection_check_boxes :resident_ids, request.user.residents, :id, :name, class: 'd-none' do |b| %>
-                          <span class="tag is-warning r-tag"><%= b.label { b.text } %>承認済</span>
+                          <% if b.object.facility_id == current_facility.id  %>
+                            <span class="tag is-warning r-tag"><%= b.label { b.text } %>承認済</span>
+                          <% end %>
                         <% end %>
                       </div>
                       <% end %>

--- a/app/views/relatives/new.html.erb
+++ b/app/views/relatives/new.html.erb
@@ -65,18 +65,24 @@
                       <%= render partial: 'shared/error_messages', locals: { obj: @request_user } if @request_user.present? %>
 
                       <%= f.fields_for "request_residents[]", request.user do |i| %>
-                      <div class="new-checkbox">
-                        <%= i.collection_check_boxes :resident_ids, @residents, :id, :name do |b| %>
-                          <span class="r-check-box"><%= b.label { b.check_box + " " + b.text } %></span>
-                        <% end %><br>
-                      </div>
-                      <div class="tag-apply">
-                        <%= i.collection_check_boxes :resident_ids, request.user.residents, :id, :name, class: 'd-none' do |b| %>
-                          <% if b.object.facility_id == current_facility.id  %>
-                            <span class="tag is-warning r-tag"><%= b.label { b.text } %>承認済</span>
+                        <div class="new-checkbox">
+                          <%= i.collection_check_boxes :resident_ids, @residents, :id, :name do |b| %>
+                            <span class="r-check-box"><%= b.label { b.check_box + " " + b.text } %></span>
+                          <% end %><br>
+                        </div>
+                        <div class="d-none">
+                          <%= i.collection_check_boxes :resident_ids, request.exclude_ids, :id, :name do |b| %>
+                            <span class="r-check-box"><%= b.label { b.check_box + " " + b.text } %></span>
                           <% end %>
-                        <% end %>
-                      </div>
+                        </div>
+
+                        <div class="tag-apply">
+                          <%= i.collection_check_boxes :resident_ids, request.user.residents, :id, :name, class: 'd-none' do |b| %>
+                            <% if b.object.facility_id == current_facility.id  %>
+                              <span class="tag is-warning r-tag"><%= b.label { b.text } %>承認済</span>
+                            <% end %>
+                          <% end %>
+                        </div>
                       <% end %>
                     </td>
                   </tr>

--- a/app/views/relatives/show.html.erb
+++ b/app/views/relatives/show.html.erb
@@ -64,7 +64,9 @@
                 </div>
                 <div class="tag-apply">
                   <%= f.collection_check_boxes :resident_ids, @user.residents, :id, :name, class: 'd-none' do |b| %>
-                    <span class="tag is-warning r-tag"><%= b.label { b.text } %>承認済</span>
+                    <% if b.object.facility_id == current_facility.id  %>
+                      <span class="tag is-warning r-tag"><%= b.label { b.text } %>承認済</span>
+                    <% end %>
                   <% end %>
                 </div>
                 <div class="propriety">

--- a/app/views/relatives/show.html.erb
+++ b/app/views/relatives/show.html.erb
@@ -64,6 +64,12 @@
                     <span class="r-check-box"><%= b.label { b.check_box + " " + b.text } %></span>
                   <% end %><br>
                 </div>
+                <div class="d-none">
+                  <%= f.collection_check_boxes :resident_ids, @request.exclude_ids, :id, :name do |b| %>
+                    <span class="r-check-box"><%= b.label { b.check_box + " " + b.text } %></span>
+                  <% end %>
+                </div>
+
                 <div class="tag-apply">
                   <%= f.collection_check_boxes :resident_ids, @user.residents, :id, :name, class: 'd-none' do |b| %>
                     <% if b.object.facility_id == current_facility.id  %>

--- a/app/views/relatives/show.html.erb
+++ b/app/views/relatives/show.html.erb
@@ -19,6 +19,8 @@
           <% end %>
         </div>
       </nav>
+
+      <div class="request-time"><span>申請日</span><%= l(@request.created_at, format: :long) %></div>
       <div class="card">
         <table class="table is-narrow user-edit-table is-bordered" id="relative-table">
           <tbody>

--- a/app/views/request_residents/new.html.erb
+++ b/app/views/request_residents/new.html.erb
@@ -20,7 +20,7 @@
               <tr>
                 <th>利用者名</th>
                 <td>
-                  <%= f.text_area :req_name, :placeholder => " \uf304 入居者名", class: "fa textarea input is-hovered req-table-edit-form" %>
+                  <%= f.text_area :req_name, :placeholder => " \uf304 利用者名", class: "fa textarea input is-hovered req-table-edit-form" %>
                 </td>
               </tr>
               <tr>

--- a/app/views/request_residents/new.html.erb
+++ b/app/views/request_residents/new.html.erb
@@ -3,7 +3,7 @@
     <div class="req-new-section">
       <h1 class="has-text-weight-bold is-size-3">利用者登録申請</h1>
       <% if @request_resident&.req_approval == "approval" && @request_resident.facility_id == params[:facility_id].to_i %>
-        <p>※利用者登録は<span class="c-red"><%= @request_resident.req_approval_i18n %></span>です。追加申請の際はご入力ください。</p>
+        <p>※利用者登録は<span><%= @request_resident.status %></span>です。追加申請の際はご入力ください。</p>
       <% end %>
       <%= form_with(model: @request, url: request_residents_path(facility_id: params[:facility_id]), local: true) do |f| %>
       <%= render "users/shared/error_messages", resource: @request %>


### PR DESCRIPTION
## Issueへのリンク
* https://github.com/hayaminahiro/family_online_visit/issues/140

## 実装内容
* ご家族ユーザが複数施設に申請していた場合に表示の崩れが起きていました
→ご家族ユーザと紐づく入居者全ての名前がどの申請においても「承認済」の欄に表示されてしまっていたので、施設ごとに表示がされるように修正
→申請中一覧で上記の場合にif文などの条件が合わずに表示崩れの発生している箇所がありましたので修正しました


## やらないこと
* なし

## できるようになること（ユーザ目線）
* なし

## できなくなること（ユーザ目線）
* なし

## 動作確認
* 複数ユーザで複数施設に申請した際に表示の崩れがないか確認しました

## その他
* 同じユーザで複数施設、異なるユーザで同じ施設に向けてなど、申請した時に表示がおかしくなっていたので解消されているかご確認お願い致します🙇‍♂️
