### PR TITLE
入居者一覧に画像登録数を表示 Feature/#169 resident memories count

### DIFF
--- a/app/assets/stylesheets/residents.scss
+++ b/app/assets/stylesheets/residents.scss
@@ -23,12 +23,12 @@
 }
 
 .button.resident--create-button {
-  padding-top: 14px!important;
+  padding-top: 14px !important;
   font-size: 20px;
 }
 
 .resident--update-button {
-  padding-top: 10px!important;
+  padding-top: 10px !important;
 }
 
 #resident-modal-form {
@@ -36,7 +36,7 @@
 }
 
 .resident-title {
-  background-color: rgb( 117, 150, 224 );
+  background-color: rgb(117, 150, 224);
 }
 
 .residents-search {
@@ -73,21 +73,23 @@
     font-size: 17px;
   }
 
-  thead th {/*table内のヘッダーに対して*/
+  thead th {
+    /*table内のヘッダーに対して*/
     color: white;
-    font-size:20px;
+    font-size: 20px;
   }
 
   thead tr {
-    background-color: rgb( 117, 150, 224 )
+    background-color: rgb(117, 150, 224);
   }
 
-  .tr-head {/*table内のラベル対して*/
-      background-color: rgb( 188, 214, 226 )
-    }
+  .tr-head {
+    /*table内のラベル対して*/
+    background-color: rgb(188, 214, 226);
+  }
 
   .text-color {
-    color:white;
+    color: white;
   }
 
   .text-left {
@@ -106,7 +108,7 @@
 }
 
 .image-count-td {
-  text-align :left !important;
+  text-align: left !important;
   padding-left: 41px !important;
   font-weight: 400;
 }
@@ -121,13 +123,14 @@
 }
 
 .resident_cp_tooltip {
-	position: relative;
-	display: inline-block;
-	cursor: pointer;
+  position: relative;
+  display: inline-block;
+  cursor: pointer;
 }
 
 .resident_cp_tooltip .resident_cp_tooltiptext {
-  box-shadow: 0 0.5em 1em -0.125em rgba(10, 10, 10, 0.1), 0 0px 0 1px rgba(10, 10, 10, 0.02);
+  box-shadow: 0 0.5em 1em -0.125em rgba(10, 10, 10, 0.1),
+    0 0px 0 1px rgba(10, 10, 10, 0.02);
   position: absolute;
   z-index: 1;
   bottom: 0px;
@@ -146,13 +149,12 @@
 }
 
 .resident_cp_tooltip:hover .resident_cp_tooltiptext {
-	visibility: visible;
-	opacity: 1;
+  visibility: visible;
+  opacity: 1;
 }
 
 //タブレット
 @media screen and (max-width: 1000px) {
-
   #file-js-example {
     width: 78%;
   }
@@ -179,7 +181,6 @@
 
 //モバイル
 @media screen and (max-width: 500px) {
-
   #file-js-example {
     font-size: 15px;
     width: 46%;

--- a/app/assets/stylesheets/residents.scss
+++ b/app/assets/stylesheets/residents.scss
@@ -89,6 +89,65 @@
   .text-color {
     color:white;
   }
+
+  .text-left {
+    text-align: left !important;
+  }
+}
+
+.image-total-count {
+  display: inline-block;
+  font-size: 10px;
+}
+
+.image-total-count-span {
+  font-size: 20px;
+  margin: 5px;
+}
+
+.image-count-td {
+  text-align :left !important;
+  padding-left: 41px !important;
+  font-weight: 400;
+}
+
+.residents-month-select {
+  display: inline;
+}
+
+.residents-month-select-form {
+  border-radius: 15px;
+  padding: 0 2px 0 5px;
+}
+
+.resident_cp_tooltip {
+	position: relative;
+	display: inline-block;
+	cursor: pointer;
+}
+
+.resident_cp_tooltip .resident_cp_tooltiptext {
+  box-shadow: 0 0.5em 1em -0.125em rgba(10, 10, 10, 0.1), 0 0px 0 1px rgba(10, 10, 10, 0.02);
+  position: absolute;
+  z-index: 1;
+  bottom: 0px;
+  left: 80px;
+  visibility: hidden;
+  width: auto;
+  white-space: nowrap;
+  padding: 0.3em 0.5em;
+  transition: opacity 0.4s;
+  text-align: center;
+  opacity: 0;
+  font-size: 15px;
+  color: red;
+  border-radius: 6px;
+  background-color: #ffffff;
+}
+
+.resident_cp_tooltip:hover .resident_cp_tooltiptext {
+	visibility: visible;
+	opacity: 1;
 }
 
 //タブレット

--- a/app/assets/stylesheets/residents.scss
+++ b/app/assets/stylesheets/residents.scss
@@ -100,11 +100,11 @@
 .image-total-count {
   display: inline-block;
   font-size: 10px;
-}
 
-.image-total-count-span {
-  font-size: 20px;
-  margin: 5px;
+  span {
+    font-size: 20px;
+    margin: 5px;
+  }
 }
 
 .image-count-td {

--- a/app/controllers/residents_controller.rb
+++ b/app/controllers/residents_controller.rb
@@ -3,7 +3,7 @@ class ResidentsController < ApplicationController
 
   def index
     @residents = Resident.search(params[:search], current_facility).paginate(page: params[:page], per_page: 30)
-    @select_month = params[:date].nil? ? Time.now : params[:date].to_date
+    @select_month = params[:date].nil? ? Time.current : params[:date].to_date
     @total_image_count = Memory.total_image_count(current_facility.residents, @select_month)
   end
 

--- a/app/controllers/residents_controller.rb
+++ b/app/controllers/residents_controller.rb
@@ -3,22 +3,8 @@ class ResidentsController < ApplicationController
 
   def index
     @residents = Resident.search(params[:search], current_facility).paginate(page: params[:page], per_page: 30)
-
-    @image_columns = []
-    @residents.each do |resident|
-      resident.memories.where(created_at: Time.now.all_month).each do |m|
-        @image_columns << m.image0 if m.image0?
-        @image_columns << m.image1 if m.image1?
-        @image_columns << m.image2 if m.image2?
-        @image_columns << m.image3 if m.image3?
-        @image_columns << m.image4 if m.image4?
-        @image_columns << m.image5 if m.image5?
-        @image_columns << m.image6 if m.image6?
-        @image_columns << m.image7 if m.image7?
-      end
-    end
-    @image_columns
-
+    @select_month = params[:date].nil? ? Time.now : params[:date].to_date
+    @total_image_count = Memory.total_image_count(current_facility.residents, @select_month)
   end
 
   def new

--- a/app/controllers/residents_controller.rb
+++ b/app/controllers/residents_controller.rb
@@ -3,6 +3,22 @@ class ResidentsController < ApplicationController
 
   def index
     @residents = Resident.search(params[:search], current_facility).paginate(page: params[:page], per_page: 30)
+
+    @image_columns = []
+    @residents.each do |resident|
+      resident.memories.where(created_at: Time.now.all_month).each do |m|
+        @image_columns << m.image0 if m.image0?
+        @image_columns << m.image1 if m.image1?
+        @image_columns << m.image2 if m.image2?
+        @image_columns << m.image3 if m.image3?
+        @image_columns << m.image4 if m.image4?
+        @image_columns << m.image5 if m.image5?
+        @image_columns << m.image6 if m.image6?
+        @image_columns << m.image7 if m.image7?
+      end
+    end
+    @image_columns
+
   end
 
   def new

--- a/app/decorators/resident_decorator.rb
+++ b/app/decorators/resident_decorator.rb
@@ -19,4 +19,19 @@ module ResidentDecorator
     end
     image_columns
   end
+
+  def this_month_image_count
+    image_columns = []
+    memories.where(created_at: Time.now.all_month).each do |m|
+      image_columns << m.image0 if m.image0?
+      image_columns << m.image1 if m.image1?
+      image_columns << m.image2 if m.image2?
+      image_columns << m.image3 if m.image3?
+      image_columns << m.image4 if m.image4?
+      image_columns << m.image5 if m.image5?
+      image_columns << m.image6 if m.image6?
+      image_columns << m.image7 if m.image7?
+    end
+    image_columns.count
+  end
 end

--- a/app/decorators/resident_decorator.rb
+++ b/app/decorators/resident_decorator.rb
@@ -20,9 +20,9 @@ module ResidentDecorator
     image_columns
   end
 
-  def this_month_image_count
+  def image_count(select_days)
     image_columns = []
-    memories.where(created_at: Time.now.all_month).each do |m|
+    memories.where(created_at: select_days).each do |m|
       image_columns << m.image0 if m.image0?
       image_columns << m.image1 if m.image1?
       image_columns << m.image2 if m.image2?

--- a/app/models/memory.rb
+++ b/app/models/memory.rb
@@ -49,4 +49,21 @@ class Memory < ApplicationRecord
     end
     image_columns
   end
+
+  def self.total_image_count(residents, day)
+    image_columns = []
+    residents.each do |resident|
+      resident.memories.where(created_at: day.all_month).each do |m|
+        image_columns << m.image0 if m.image0?
+        image_columns << m.image1 if m.image1?
+        image_columns << m.image2 if m.image2?
+        image_columns << m.image3 if m.image3?
+        image_columns << m.image4 if m.image4?
+        image_columns << m.image5 if m.image5?
+        image_columns << m.image6 if m.image6?
+        image_columns << m.image7 if m.image7?
+      end
+    end
+    image_columns.count
+  end
 end

--- a/app/models/memory.rb
+++ b/app/models/memory.rb
@@ -53,7 +53,7 @@ class Memory < ApplicationRecord
   def self.total_image_count(residents, day)
     image_columns = []
     residents.each do |resident|
-      resident.memories.where(created_at: day.all_month).each do |m|
+      resident.memories.where(created_at: day.all_month).find_each do |m|
         image_columns << m.image0 if m.image0?
         image_columns << m.image1 if m.image1?
         image_columns << m.image2 if m.image2?

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -70,7 +70,7 @@
             <% if user_signed_in? %>
               <%= link_to "設定", edit_user_registration_path(resource_name), :style=>"color: #595a5a;", class: "navbar-item has-text-weight-bold is-size-6" %>
             <% elsif facility_signed_in? %>
-              <%= link_to "設定", edit_facility_registration_path, class: "navbar-item has-text-weight-bold is-size-6" %>
+              <%= link_to "設定", edit_facility_registration_path(anchor: 'top'), class: "navbar-item has-text-weight-bold is-size-6" %>
             <% end %>
             <hr class="navbar-divider">
               <%= link_to "ログアウト", sign_out_path, class: "navbar-item has-text-weight-bold is-size-6" %>

--- a/app/views/memories/_event_card.html.erb
+++ b/app/views/memories/_event_card.html.erb
@@ -14,17 +14,11 @@
                 <i class="fas fa-folder-open fa-3x"></i>
               <% end %>
 
-              <% if facility_signed_in? %>
-                <%= link_to new_resident_memory_path(resident, add_images: m), class: "folder" do %>
-                  <i class="fas fa-folder-plus fa-3x"></i>
-                <% end %>
-              <% end %>
               <p class="photo-card-text">行事日: <%= l(m.event_date, format: :long) %></p>
             </div>
           </section>
         </div>
       <% end %>
-      <%# <div class="bottom-control">&nbsp;</div> %>
     <% end %>
 
   <% else %>

--- a/app/views/residents/index.html.erb
+++ b/app/views/residents/index.html.erb
@@ -58,7 +58,10 @@
                 <th>利用者名</th>
                 <th>ご家族名</th>
                 <th>担当者名</th>
-                <th>思い出アルバム</th>
+                <th>
+                  思い出アルバム
+                  <%= @image_columns.count %>
+                </th>
                 <th>編集</th>
                 <th>退所</th>
                 <th>削除</th>

--- a/app/views/residents/index.html.erb
+++ b/app/views/residents/index.html.erb
@@ -78,6 +78,8 @@
                   <%= link_to resident_memories_path(resident), class:"button is-link" do %>
                     <i class="fas fa-images"></i>
                   <% end %>
+                  <!--毎月の画像投稿数-->
+                  <%= resident.this_month_image_count %>
                 </td>
                 <td>
                   <div class=" js-contents--edit-button">

--- a/app/views/residents/index.html.erb
+++ b/app/views/residents/index.html.erb
@@ -67,7 +67,7 @@
                   <div class="js-contents--content">
                     <div class="image-total-count">合計<span class="image-total-count-span"><%= @total_image_count %></span>枚</div>
                       <%= form_with model: current_facility, url:  residents_path(current_facility), class: "residents-month-select", method: :get, remote: true do |f| %>
-                        <%= f.select :user_id, [[ @select_month.prev_month.prev_month.strftime("%y年 %m月"), residents_path(anchor: "table", date: @select_month.prev_month.prev_month.all_month, user_id: current_facility.id)],
+                        <%= f.select :user_id, [[ @select_month.prev_month.prev_month.strftime("%y年 %m月"), residents_path(anchor: "table", date: @select_month.prev_month.prev_month.all_month)],
                                                 [ @select_month.prev_month.strftime("%y年 %m月"), residents_path(anchor: "table", date: @select_month.prev_month.all_month)],
                                                 [ @select_month.strftime("%y年 %m月"), residents_path(anchor: "table", date: @select_month.all_month)],
                                                 [ @select_month.next_month.strftime("%y年 %m月"), residents_path(anchor: "table", date: @select_month.next_month.all_month)]

--- a/app/views/residents/index.html.erb
+++ b/app/views/residents/index.html.erb
@@ -66,7 +66,7 @@
                 <th class="text-left">
                   <div class="js-contents--content">
                     <div class="image-total-count">合計<span class="image-total-count-span"><%= @total_image_count %></span>枚</div>
-                      <%= form_with model: current_facility, url:  residents_path(current_facility), class: "residents-month-select", method: :get, remote: true do |f| %>
+                      <%= form_with model: current_facility, url:  residents_path(current_facility), class: "residents-month-select", method: :get do |f| %>
                         <%= f.select :user_id, [[ @select_month.prev_month.prev_month.strftime("%y年 %m月"), residents_path(anchor: "table", date: @select_month.prev_month.prev_month.all_month)],
                                                 [ @select_month.prev_month.strftime("%y年 %m月"), residents_path(anchor: "table", date: @select_month.prev_month.all_month)],
                                                 [ @select_month.strftime("%y年 %m月"), residents_path(anchor: "table", date: @select_month.all_month)],

--- a/app/views/residents/index.html.erb
+++ b/app/views/residents/index.html.erb
@@ -65,7 +65,7 @@
                 </th>
                 <th class="text-left">
                   <div class="js-contents--content">
-                    <div class="image-total-count">合計<span class="image-total-count-span"><%= @total_image_count %></span>枚</div>
+                    <div class="image-total-count">合計<span><%= @total_image_count %></span>枚</div>
                       <%= form_with model: current_facility, url:  residents_path(current_facility), class: "residents-month-select", method: :get do |f| %>
                         <%= f.select :user_id, [[ @select_month.prev_month.prev_month.strftime("%y年 %m月"), residents_path(anchor: "table", date: @select_month.prev_month.prev_month.all_month)],
                                                 [ @select_month.prev_month.strftime("%y年 %m月"), residents_path(anchor: "table", date: @select_month.prev_month.all_month)],

--- a/app/views/residents/index.html.erb
+++ b/app/views/residents/index.html.erb
@@ -55,12 +55,25 @@
           <table class="table is-striped is-fullwidth" id="table-residents">
             <thead>
               <tr class="has-text-weight-bold">
-                <th>利用者名</th>
+                <th>
+                  利用者名(<%= current_facility.residents.count %>)
+                </th>
                 <th>ご家族名</th>
                 <th>担当者名</th>
                 <th>
                   思い出アルバム
-                  <%= @image_columns.count %>
+                </th>
+                <th class="text-left">
+                  <div class="js-contents--content" id="table">
+                    <div class="image-total-count">合計<span class="image-total-count-span"><%= @total_image_count %></span>枚</div>
+                      <%= form_with model: current_facility, url:  residents_path(current_facility), class: "residents-month-select", method: :get, remote: true do |f| %>
+                        <%= f.select :user_id, [[ @select_month.prev_month.prev_month.strftime("%y年 %m月"), residents_path(anchor: "table", date: @select_month.prev_month.prev_month.all_month, user_id: current_facility.id)],
+                                                [ @select_month.prev_month.strftime("%y年 %m月"), residents_path(anchor: "table", date: @select_month.prev_month.all_month)],
+                                                [ @select_month.strftime("%y年 %m月"), residents_path(anchor: "table", date: @select_month.all_month)],
+                                                [ @select_month.next_month.strftime("%y年 %m月"), residents_path(anchor: "table", date: @select_month.next_month.all_month)]
+                                              ], { selected: residents_path(anchor: "table", date: @select_month.all_month) }, { class: "residents-month-select-form" } %>
+                      <% end %>
+                  </div>
                 </th>
                 <th>編集</th>
                 <th>退所</th>
@@ -81,8 +94,9 @@
                   <%= link_to resident_memories_path(resident), class:"button is-link" do %>
                     <i class="fas fa-images"></i>
                   <% end %>
-                  <!--毎月の画像投稿数-->
-                  <%= resident.this_month_image_count %>
+                </td>
+                <td class="image-count-td">
+                  <%= resident.image_count(@select_month.all_month) %>
                 </td>
                 <td>
                   <div class=" js-contents--edit-button">
@@ -178,4 +192,27 @@
     ScrollReveal().reveal('.facility-icon-image', { delay: 600, distance: '70%', origin: 'top', duration: 2000, viewFactor: 0.5 });
     ScrollReveal().reveal('#facility-name', { delay: 100, distance: '100%', origin: 'left', duration: 2000, viewFactor: 0.5 });
   });
+</script>
+
+<script>
+  // select変更時
+  $(function() {
+    $('select').change(function() {
+      var url = $(this).val();
+
+      if(url != '') {
+        location.href = url
+      }
+    })
+  });
+  // 画面遷移後
+  var headerHeight = $('.navbar-brand').outerHeight();
+  var urlHash = location.hash;
+  if(urlHash) {
+    setTimeout(function(){
+      var target = $(urlHash);
+      var position = target.offset().top - (headerHeight + 80);
+      $('body,html').scrollTop(position);
+    }, 330);
+  }
 </script>

--- a/app/views/residents/index.html.erb
+++ b/app/views/residents/index.html.erb
@@ -6,7 +6,7 @@
     <section class="resident-title hero">
       <div class="hero-body">
         <div class="container has-text-centered">
-          <h1 class="title is-size-3 has-text-white">
+          <h1 class="title is-size-3 has-text-white" id="table">
             利用者一覧
           </h1>
         </div>
@@ -64,7 +64,7 @@
                   思い出アルバム
                 </th>
                 <th class="text-left">
-                  <div class="js-contents--content" id="table">
+                  <div class="js-contents--content">
                     <div class="image-total-count">合計<span class="image-total-count-span"><%= @total_image_count %></span>枚</div>
                       <%= form_with model: current_facility, url:  residents_path(current_facility), class: "residents-month-select", method: :get, remote: true do |f| %>
                         <%= f.select :user_id, [[ @select_month.prev_month.prev_month.strftime("%y年 %m月"), residents_path(anchor: "table", date: @select_month.prev_month.prev_month.all_month, user_id: current_facility.id)],
@@ -205,14 +205,4 @@
       }
     })
   });
-  // 画面遷移後
-  var headerHeight = $('.navbar-brand').outerHeight();
-  var urlHash = location.hash;
-  if(urlHash) {
-    setTimeout(function(){
-      var target = $(urlHash);
-      var position = target.offset().top - (headerHeight + 80);
-      $('body,html').scrollTop(position);
-    }, 330);
-  }
 </script>

--- a/app/views/shared/_facility_images.html.erb
+++ b/app/views/shared/_facility_images.html.erb
@@ -2,15 +2,16 @@
   <div class="facility-home-image">
     <% if current_page?('/facilities/edit') %>
       <%= facility.facility_edit_background_image %>
-    <% else %>  
+    <% else %>
       <%= facility.facility_background_image %>
-    <% end %>  
+    <% end %>
     <div class="image-outline" id="scroll-position">
       <% if facility.icon? %>
         <%= image_tag facility.icon.url, class: "facility-icon-image" %>
       <% else %>
         <%= image_tag 'https://img-photo.s3-ap-northeast-1.amazonaws.com/uploads/content_image/facility_default.png', class: "facility-icon-image" %>
-      <% end %>  
+      <% end %>
+      <div id="top"></div>
       <div class="has-text-right" id="facility-name">
         <%= facility.facility_name %>
       </div>
@@ -27,13 +28,13 @@
         <div class="user-edit-background-back">
           <div class="user-edit-backgroung-image">
             <i class="fas fa-camera"></i>
-          </div>  
+          </div>
         </div>
       </div>
     <% else %>
       <div class="facility-icon-outline">
         <%= facility.facility_icon_responsive %>
       </div>
-    <% end %>  
+    <% end %>
   </div>
 </section>

--- a/app/views/shared/_side_link.html.erb
+++ b/app/views/shared/_side_link.html.erb
@@ -9,9 +9,9 @@
           </span>&nbsp;
           HOME
         <% end %>
-      </li>  
+      </li>
       <li>
-        <%= link_to residents_path do %>
+        <%= link_to residents_path(anchor: 'top') do %>
           <span class="icon">
             <i class="fas fa-id-badge"></i>
           </span>&nbsp;
@@ -19,7 +19,7 @@
         <% end %>
       </li>
       <li>
-        <%= link_to users_path do %>
+        <%= link_to users_path(anchor: 'top') do %>
           <span class="icon">
             <i class="fas fa-user-friends"></i>
           </span>&nbsp;
@@ -35,7 +35,7 @@
         <% end %>
       </li>
       <li>
-        <%= link_to informations_path do %>
+        <%= link_to informations_path(anchor: 'top') do %>
           <span class="icon">
             <i class="far fa-bell"></i>
           </span>&nbsp;
@@ -43,7 +43,7 @@
         <% end %>
       </li>
       <li>
-        <%= link_to facility_inquiries_path(facility_id: current_facility.id) do %>
+        <%= link_to facility_inquiries_path(facility_id: current_facility.id, anchor: 'top') do %>
           <span class="icon">
             <i class="fas fa-phone"></i>
           </span>&nbsp;
@@ -53,3 +53,14 @@
     </ul>
   </section>
 </div>
+
+<script>
+  var headerHeight = $('.navbar-brand').outerHeight();
+  var urlHash = location.hash;
+  if(urlHash) {
+    var target = $(urlHash);
+    var position = target.offset().top - headerHeight;
+
+    $('body,html').stop().animate({scrollTop:position}, 800);
+  }
+</script>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -206,6 +206,7 @@ ja:
       default: "%Y年%m月%d日(%a) %H時%M分%S秒 %z"
       default_info: "%Y年%m月%d日(%a) %H時%M分"
       date: "%Y年%m月%d日(%a)"
+      year_month: "%Y年%m月"
       long: "%Y/%m/%d %H:%M"
       short: "%m/%d %H:%M"
       time: "%H:%M"


### PR DESCRIPTION
## Issueへのリンク
* https://github.com/hayaminahiro/family_online_visit/issues/169#issue-787701430

## 実装内容
* 入居者一覧に画像投稿数を表示できるようにした
* パソコン表示の場合のみ、サイドのリンクから遷移後にスクロールする機能を追加
→　「ご家族一覧、入居者一覧、お知らせ、お問い合わせページ」に遷移した時のみ設定してみました。
       HOMEはあえて画像全体が見えていたほうがいいかなと思ったのでひとまず設定しませんでした。

* prettierでresident.cssファイルを修正

## やらないこと
* なし

## できるようになること（ユーザ目線）
* 施設の管理者が月毎の画像投稿数を確認できるようになる

## できなくなること（ユーザ目線）
* なし

## 動作確認
* 画面遷移して問題なく遷移できるかの確認をしました。
