### PR TITLE
モバイルでの新規登録画面遷移時のエラーを修正

### DIFF
--- a/app/views/facilities/registrations/new.html.erb
+++ b/app/views/facilities/registrations/new.html.erb
@@ -19,7 +19,7 @@
 
           <div class="field">
             <%= f.label :email, class: "label" %><br />
-            <%= f.email_field :email, :placeholder => "\uf0e0 メールアドレスを入力", autofocus: true, autocomplete: "email", class: "fa input is-medium input-top" %>
+            <%= f.email_field :email, :placeholder => "\uf0e0 メールアドレスを入力", autocomplete: "email", class: "fa input is-medium input-top" %>
           </div>
 
           <div class="field">

--- a/app/views/signup/step1.html.erb
+++ b/app/views/signup/step1.html.erb
@@ -46,7 +46,7 @@
 
         <div class="field-signup">
           <%= f.label :email, class: "label" %><br />
-          <%= f.email_field :email, :placeholder => "\uf0e0 メールアドレスを入力", value: session[:email], autofocus: true, autocomplete: "email", class: "fa input is-medium input-top", style: "ime-mode:disabled;" %>
+          <%= f.email_field :email, :placeholder => "\uf0e0 メールアドレスを入力", value: session[:email], autocomplete: "email", class: "fa input is-medium input-top", style: "ime-mode:disabled;" %>
         </div>
 
         <div class="field-signup">


### PR DESCRIPTION
## Issueへのリンク
* https://github.com/hayaminahiro/family_online_visit/issues/195#issue-807769963

## 実装内容
* モバイルでの新規登録画面への遷移時のエラー修正（ユーザ登録・施設登録）

## やらないこと
* なし

## できるようになること（ユーザ目線）
* なし

## できなくなること（ユーザ目線）
* なし

## 動作確認
* 2/14ミーティング内で動作確認
