### PR TITLE
EC2向けにport番号変更/pid削除追加 #201

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,13 +10,15 @@ services:
 
   web:
     build: .
-    command: rails s -p 3000 -b '0.0.0.0'
+    # railsコマンドの前にpidファイルを削除
+    command: /bin/sh -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
     stdin_open: true
     tty: true
     volumes:
       - .:/app_name
     ports:
-      - "3000:3000"
+      # "host-port(80):container-port(3000)" => EC2で80番portにリクエストが来ると、内部で3000番portに渡してあげる
+      - "80:3000"
     links:
       - db
     environment:


### PR DESCRIPTION
## Issueへのリンク
* https://github.com/hayaminahiro/family_online_visit/issues/201

## 実装内容
* AWSデプロイ(Puma)

## やらないこと
* Nginx
* Unicorn

## できるようになること（ユーザ目線）
* AWSでhttps通信

## できなくなること（ユーザ目線）
* herokuへのアクセス

## 動作確認
* EC2上でlogの確認、Web上でアクセス

## その他
* このタスクのpid削除の部分をmergeしないと定期的に接続エラーになる事が分かりました。merge後は恐らくそのようなエラーは消えるはずです。
