### PR TITLE
本番環境用のファイル作成

### DIFF
--- a/docker-compose.pro.yml
+++ b/docker-compose.pro.yml
@@ -1,4 +1,3 @@
-# AWS版(Nginx & Unicorn)
 version: '3'
 services:
   # データベースのサービス定義
@@ -16,7 +15,7 @@ services:
   # アプリケーションサーバーのサービス定義
   web:
     build: .
-    # unicorn.pidを事前に削除
+    # unicorn使用
     command: /bin/sh -c "rm -f tmp/pids/unicorn.pid && dockerize -wait tcp://db:3306 -timeout 20s bundle exec unicorn -p 3000 -c /app_name/config/unicorn.conf.rb -E production"
     volumes:
       - .:/app_name
@@ -33,8 +32,6 @@ services:
     stdin_open: true
     links:
       - db
-    environment:
-    - "SELENIUM_DRIVER_URL=http://selenium_chrome:4444/wd/hub"
 
   # WEBサーバーのサービス定義
   nginx:
@@ -49,11 +46,6 @@ services:
       - public-data:/app_name/public
     links:
       - web
-
-  selenium_chrome:
-    image: selenium/standalone-chrome-debug
-    logging:
-      driver: none
 
 volumes:
   public-data:

--- a/docker-compose.pro.yml
+++ b/docker-compose.pro.yml
@@ -1,0 +1,63 @@
+# AWS版(Nginx & Unicorn)
+version: '3'
+services:
+  # データベースのサービス定義
+  db:
+    image: mysql:5.7
+    command: mysqld --character-set-server=utf8 --collation-server=utf8_unicode_ci
+    volumes:
+      - db-volume:/var/lib/mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: password
+      MYSQL_DATABASE: root
+    ports:
+      - '3306:3306'
+
+  # アプリケーションサーバーのサービス定義
+  web:
+    build: .
+    # unicorn.pidを事前に削除
+    command: /bin/sh -c "rm -f tmp/pids/unicorn.pid && dockerize -wait tcp://db:3306 -timeout 20s bundle exec unicorn -p 3000 -c /app_name/config/unicorn.conf.rb -E production"
+    volumes:
+      - .:/app_name
+      - bundle:/usr/local/bundle:delegated
+      - tmp-data:/app_name/tmp/sockets
+      - public-data:/app_name/public
+      - /app/vendor
+      - /app/tmp
+      - /app/log
+      - /app/.git
+    ports:
+      - "3000:3000"
+    tty: true
+    stdin_open: true
+    links:
+      - db
+    environment:
+    - "SELENIUM_DRIVER_URL=http://selenium_chrome:4444/wd/hub"
+
+  # WEBサーバーのサービス定義
+  nginx:
+    build:
+      context: ./nginx
+      dockerfile: Dockerfile
+    ports:
+      - 80:80
+    restart: always
+    volumes:
+      - tmp-data:/app_name/tmp/sockets
+      - public-data:/app_name/public
+    links:
+      - web
+
+  selenium_chrome:
+    image: selenium/standalone-chrome-debug
+    logging:
+      driver: none
+
+volumes:
+  public-data:
+  tmp-data:
+  mysql-data:
+  db-volume:
+  bundle:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-# AWS版(Nginx & Unicorn)
 version: '3'
 services:
   # データベースのサービス定義
@@ -16,8 +15,8 @@ services:
   # アプリケーションサーバーのサービス定義
   web:
     build: .
-    # unicorn.pidを事前に削除
-    command: /bin/sh -c "rm -f tmp/pids/unicorn.pid && dockerize -wait tcp://db:3306 -timeout 20s bundle exec unicorn -p 3000 -c /app_name/config/unicorn.conf.rb"
+    # puma使用
+    command: /bin/sh -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
     volumes:
       - .:/app_name
       - bundle:/usr/local/bundle:delegated
@@ -35,20 +34,6 @@ services:
       - db
     environment:
     - "SELENIUM_DRIVER_URL=http://selenium_chrome:4444/wd/hub"
-
-  # WEBサーバーのサービス定義
-  nginx:
-    build:
-      context: ./nginx
-      dockerfile: Dockerfile
-    ports:
-      - 80:80
-    restart: always
-    volumes:
-      - tmp-data:/app_name/tmp/sockets
-      - public-data:/app_name/public
-    links:
-      - web
 
   selenium_chrome:
     image: selenium/standalone-chrome-debug


### PR DESCRIPTION
## Issueへのリンク
* https://github.com/hayaminahiro/family_online_visit/issues/220

## 実装内容
* 本番環境で画像がS3に保存されていなかった。原因はproduction環境で動いていなかったこと。
* command: /bin/sh -c "rm -f tmp/pids/unicorn.pid && dockerize -wait tcp://db:3306 -timeout 20s bundle exec unicorn -p 3000 -c /app_name/config/unicorn.conf.rb -E production"
* -E productionを加えてあげれば本番環境で作動しS3に画像が保存されていく事が確認できた。

## 動作確認
* AWS上でコンテナに入ってファイル操作してS3への画像保存と本番環境独自のエラーページが表示されていることを確認

## その他
* https://zukucode.com/2020/08/docker-compose-dev.html
* 上記記事を参考↓
* docker-compose -f docker-compose.yml -f docker-compose.pro.yml build
* docker-compose -f docker-compose.yml -f docker-compose.pro.yml up -d
* AWS上では上記コマンドを打ちます。-fはファイル指定の意味。docker-compose.ymlファイルに、docker-compose.pro.ymlファルがmergeされ、 docker-compose.pro.ymlが本番環境で使用されることになります。
* 開発環境でははdocker-compose build, docker-compose upでdocker-compose.ymlが使用されます。つまり開発環境が作動します。

* https://qiita.com/Esfahan/items/75ade0233fe02ab04381
* 上記記事は、本番環境用のDB操作をする時に役立ちました。
